### PR TITLE
Fix SwapSink.depositCapacity() type check on from Vault

### DIFF
--- a/cadence/contracts/connectors/SwapStack.cdc
+++ b/cadence/contracts/connectors/SwapStack.cdc
@@ -206,7 +206,7 @@ access(all) contract SwapStack {
 
         access(all) fun depositCapacity(from: auth(FungibleToken.Withdraw) &{FungibleToken.Vault}) {
             let limit = self.sink.minimumCapacity()
-            if from.balance == 0.0 || limit == 0.0 || !from.getType().isInstance(self.getSinkType()) {
+            if from.balance == 0.0 || limit == 0.0 || from.getType() != self.getSinkType() {
                 return // nothing to swap from, no capacity to ingest, invalid Vault type - do nothing
             }
 


### PR DESCRIPTION
### Description

When working on https://github.com/onflow/tidal-sc/pull/7 a bug was noticed on deposits to SwapSink. This PR fixes the type check to ensure deposit execute for the correct Vault types.