### PR TITLE
[S6.2] undo changes from #43 addressing audit item S6.2

### DIFF
--- a/cadence/contracts/connectors/band-oracle/BandOracleConnectors.cdc
+++ b/cadence/contracts/connectors/band-oracle/BandOracleConnectors.cdc
@@ -106,6 +106,9 @@ access(all) contract BandOracleConnectors {
                 assert(now < priceData.baseTimestamp + self.staleThreshold!, 
                     message: "Price data's base timestamp \(priceData.baseTimestamp) exceeds the staleThreshold "
                         .concat("\(priceData.baseTimestamp + self.staleThreshold!) at current timestamp \(now)"))
+                assert(now < priceData.quoteTimestamp + self.staleThreshold!,
+                    message: "Price data's quote timestamp \(priceData.quoteTimestamp) exceeds the staleThreshold "
+                        .concat("\(priceData.quoteTimestamp + self.staleThreshold!) at current timestamp \(now)"))
             }
 
             return priceData.fixedPointRate


### PR DESCRIPTION
### Description

- Add formerly removed assertion on the quote timestamp in `BandOracleConnectors.cdc`