### PR TITLE
Add SequentialSwapper to SwapConnectors + test cases & mocks

### DIFF
--- a/cadence/tests/SwapConnectorsSequentialSwapper_test.cdc
+++ b/cadence/tests/SwapConnectorsSequentialSwapper_test.cdc
@@ -1,0 +1,176 @@
+import Test
+import BlockchainHelpers
+import "test_helpers.cdc"
+
+import "TokenA"
+import "TokenB"
+import "TokenC"
+
+import "DeFiActions"
+import "IncrementFiSwapConnectors"
+
+access(all) let testTokenAccount = Test.getAccount(0x0000000000000010)
+access(all) let serviceAccount = Test.serviceAccount()
+
+access(all) let tokenAIdentifier = Type<@TokenA.Vault>().identifier // "A.<ADDRESS>.TokenA.Vault"
+access(all) let tokenBIdentifier = Type<@TokenB.Vault>().identifier // "A.<ADDRESS>.TokenB.Vault"
+access(all) let tokenCIdentifier = Type<@TokenC.Vault>().identifier // "A.<ADDRESS>.TokenC.Vault"
+
+access(all)
+fun setup() {
+    // deploy test token contracts
+    var err = Test.deployContract(
+        name: "TestTokenMinter",
+        path: "./contracts/TestTokenMinter.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+    err = Test.deployContract(
+        name: "TokenA",
+        path: "./contracts/TokenA.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+    err = Test.deployContract(
+        name: "TokenB",
+        path: "./contracts/TokenB.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+    err = Test.deployContract(
+        name: "TokenC",
+        path: "./contracts/TokenC.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+
+    err = Test.deployContract(
+        name: "DeFiActionsUtils",
+        path: "../contracts/utils/DeFiActionsUtils.cdc",
+        arguments: [],
+    )
+    Test.expect(err, Test.beNil())
+    err = Test.deployContract(
+        name: "DeFiActions",
+        path: "../contracts/interfaces/DeFiActions.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+    err = Test.deployContract(
+        name: "FungibleTokenConnectors",
+        path: "../contracts/connectors/FungibleTokenConnectors.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+    err = Test.deployContract(
+        name: "SwapConnectors",
+        path: "../contracts/connectors/SwapConnectors.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+    err = Test.deployContract(
+        name: "MockSwapper",
+        path: "./contracts/MockSwapper.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+
+    transferFlow(signer: serviceAccount, recipient: testTokenAccount.address, amount: 10.0)
+}
+
+access(all)
+fun testConnectorMockSwapSucceeds() {
+    let amountIn = 10.0
+    let priceRatio = 0.5
+    let mockSwapperConfigs: [{String: AnyStruct}] = [
+        {
+            "inVault": Type<@TokenA.Vault>(),
+            "outVault": Type<@TokenB.Vault>(),
+            "inVaultPath": TokenA.VaultStoragePath,
+            "outVaultPath": TokenB.VaultStoragePath,
+            "priceRatio": 0.5
+        }, {
+            "inVault": Type<@TokenB.Vault>(),
+            "outVault": Type<@TokenC.Vault>(),
+            "inVaultPath": TokenB.VaultStoragePath,
+            "outVaultPath": TokenC.VaultStoragePath,
+            "priceRatio": 0.5
+        }
+    ]
+    let expectedOut = amountIn * priceRatio * priceRatio
+
+    let quoteOut = executeScript(
+            "./scripts/sequential-swapper/mock_quote.cdc",
+            [testTokenAccount.address, mockSwapperConfigs, amountIn, true, false]
+        )
+    Test.expect(quoteOut, Test.beSucceeded())
+    let actualQuoteOut = quoteOut.returnValue! as! {DeFiActions.Quote}
+    Test.assertEqual(expectedOut, actualQuoteOut.outAmount)
+
+    let quoteIn = executeScript(
+            "./scripts/sequential-swapper/mock_quote.cdc",
+            [testTokenAccount.address, mockSwapperConfigs, expectedOut, false, false]
+        )
+    Test.expect(quoteIn, Test.beSucceeded())
+    let actualQuoteIn = quoteIn.returnValue! as! {DeFiActions.Quote}
+    Test.assertEqual(amountIn, actualQuoteIn.inAmount)
+
+    let amountOutRes = executeScript(
+            "./scripts/sequential-swapper/mock_swap.cdc",
+            [testTokenAccount.address, mockSwapperConfigs, amountIn]
+        )
+    Test.expect(amountOutRes, Test.beSucceeded())
+    let actualOut = amountOutRes.returnValue! as! UFix64
+    Test.assertEqual(expectedOut, actualOut)
+}
+
+access(all)
+fun testConnectorMockSwapBackSucceeds() {
+    log("testConnectorMockSwapBackSucceeds() =================================================")
+    let amountIn = 10.0
+    let priceRatio = 0.5
+    let mockSwapperConfigs: [{String: AnyStruct}] = [
+        {
+            "inVault": Type<@TokenA.Vault>(),
+            "outVault": Type<@TokenB.Vault>(),
+            "inVaultPath": TokenA.VaultStoragePath,
+            "outVaultPath": TokenB.VaultStoragePath,
+            "priceRatio": 0.5
+        }, {
+            "inVault": Type<@TokenB.Vault>(),
+            "outVault": Type<@TokenC.Vault>(),
+            "inVaultPath": TokenB.VaultStoragePath,
+            "outVaultPath": TokenC.VaultStoragePath,
+            "priceRatio": 0.5
+        }
+    ]
+    let expectedOut = amountIn / priceRatio / priceRatio
+
+    log("inAmount: \(amountIn)")
+    log("expectedOut: \(expectedOut)")
+
+    let quoteOut = executeScript(
+            "./scripts/sequential-swapper/mock_quote.cdc",
+            [testTokenAccount.address, mockSwapperConfigs, amountIn, true, true]
+        )
+    Test.expect(quoteOut, Test.beSucceeded())
+    let actualQuoteOut = quoteOut.returnValue! as! {DeFiActions.Quote}
+    Test.assertEqual(expectedOut, actualQuoteOut.outAmount)
+
+    let quoteIn = executeScript(
+            "./scripts/sequential-swapper/mock_quote.cdc",
+            [testTokenAccount.address, mockSwapperConfigs, expectedOut, false, true]
+        )
+    Test.expect(quoteIn, Test.beSucceeded())
+    let actualQuoteIn = quoteIn.returnValue! as! {DeFiActions.Quote}
+    Test.assertEqual(amountIn, actualQuoteIn.inAmount)
+
+    let amountOutRes = executeScript(
+            "./scripts/sequential-swapper/mock_swap_back.cdc",
+            [testTokenAccount.address, mockSwapperConfigs, amountIn]
+        )
+    Test.expect(amountOutRes, Test.beSucceeded())
+    let actualOut = amountOutRes.returnValue! as! UFix64
+    Test.assertEqual(expectedOut, actualOut)
+    log("testConnectorMockSwapBackSucceeds() =================================================")
+}

--- a/cadence/tests/contracts/MockSwapper.cdc
+++ b/cadence/tests/contracts/MockSwapper.cdc
@@ -1,0 +1,117 @@
+import "Burner"
+import "FungibleToken"
+
+import "DeFiActions"
+import "DeFiActionsUtils"
+
+/// TEST-ONLY mock swapper that withdraws output from a user-provided Vault capability.
+/// Do NOT use in production.
+access(all) contract MockSwapper {
+
+    access(all) struct BasicQuote : DeFiActions.Quote {
+        access(all) let inType: Type
+        access(all) let outType: Type
+        access(all) let inAmount: UFix64
+        access(all) let outAmount: UFix64
+        init(inType: Type, outType: Type, inAmount: UFix64, outAmount: UFix64) {
+            self.inType = inType
+            self.outType = outType
+            self.inAmount = inAmount
+            self.outAmount = outAmount
+        }
+    }
+
+    access(all) struct Swapper : DeFiActions.Swapper {
+        access(self) let inVault: Type
+        access(self) let outVault: Type
+        access(self) let inVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>
+        access(self) let outVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>
+        access(self) let priceRatio: UFix64 // out per unit in
+        access(contract) var uniqueID: DeFiActions.UniqueIdentifier?
+
+        init(
+            inVault: Type,
+            outVault: Type,
+            inVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>,
+            outVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>,
+            priceRatio: UFix64,
+            uniqueID: DeFiActions.UniqueIdentifier?
+        ) {
+            pre {
+                inVault.isSubtype(of: Type<@{FungibleToken.Vault}>()): "inVault must be a FungibleToken Vault"
+                outVault.isSubtype(of: Type<@{FungibleToken.Vault}>()): "outVault must be a FungibleToken Vault"
+                inVaultSource.check(): "Invalid inVaultSource capability"
+                outVaultSource.check(): "Invalid outVaultSource capability"
+                priceRatio > 0.0: "Invalid price ratio"
+            }
+            self.inVault = inVault
+            self.outVault = outVault
+            self.inVaultSource = inVaultSource
+            self.outVaultSource = outVaultSource
+            self.priceRatio = priceRatio
+            self.uniqueID = uniqueID
+        }
+
+        access(all) view fun inType(): Type { return self.inVault }
+        access(all) view fun outType(): Type { return self.outVault }
+
+        access(all) fun quoteIn(forDesired: UFix64, reverse: Bool): {DeFiActions.Quote} {
+            log(reverse ? "\(self.outType().identifier) -> \(self.inType().identifier)" : "\(self.inType().identifier) -> \(self.outType().identifier)")
+            let inAmt = reverse ? forDesired * self.priceRatio : forDesired / self.priceRatio
+            log("MockSwapper quoteIn - forDesired: \(forDesired) | reverse: \(reverse) | inAmt: \(inAmt)")
+            return BasicQuote(
+                inType: reverse ? self.outType() : self.inType(),
+                outType: reverse ? self.inType() : self.outType(),
+                inAmount: inAmt,
+                outAmount: forDesired
+            )
+        }
+
+        access(all) fun quoteOut(forProvided: UFix64, reverse: Bool): {DeFiActions.Quote} {
+            log(reverse ? "\(self.outType().identifier) -> \(self.inType().identifier)" : "\(self.inType().identifier) -> \(self.outType().identifier)")
+            let outAmt = reverse ? forProvided / self.priceRatio : forProvided * self.priceRatio
+            log("MockSwapper quoteOut - forProvided: \(forProvided) | reverse: \(reverse) | outAmt: \(outAmt)")
+            return BasicQuote(
+                inType: reverse ? self.outType() : self.inType(),
+                outType: reverse ? self.inType() : self.outType(),
+                inAmount: forProvided,
+                outAmount: outAmt
+            )
+        }
+
+        access(all) fun swap(quote: {DeFiActions.Quote}?, inVault: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+            pre { inVault.getType() == self.inType(): "Wrong in type \(inVault.getType().identifier) - expected \(self.inType().identifier)" }
+            let outAmt = (quote?.outAmount) ?? (inVault.balance * self.priceRatio)
+
+            // deposit tokens back to the outVaultSource
+            let depositTo = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            depositTo.deposit(from: <-inVault)
+
+            // withdraw tokens from the inVaultSource & return
+            let src = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            return <- src.withdraw(amount: outAmt)
+        }
+
+        access(all) fun swapBack(quote: {DeFiActions.Quote}?, residual: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+            pre { residual.getType() == self.outType(): "Wrong out type \(residual.getType().identifier) - expected \(self.outType().identifier)" }
+            let inAmt = (quote?.inAmount) ?? (residual.balance / self.priceRatio)
+
+            // deposit tokens back to the inVaultSource
+            let depositTo = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            depositTo.deposit(from: <-residual)
+
+            // withdraw tokens from the outVaultSource & return
+            let src = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            log("MockSwapper swapBack returning: \(src.getType().identifier)")
+            return <- src.withdraw(amount: inAmt)
+        }
+
+        access(all) fun getComponentInfo(): DeFiActions.ComponentInfo {
+            return DeFiActions.ComponentInfo(type: self.getType(), id: self.id(), innerComponents: [])
+        }
+        access(contract) view fun copyID(): DeFiActions.UniqueIdentifier? { return self.uniqueID }
+        access(contract) fun setID(_ id: DeFiActions.UniqueIdentifier?) { self.uniqueID = id }
+    }
+}
+
+

--- a/cadence/tests/contracts/TokenC.cdc
+++ b/cadence/tests/contracts/TokenC.cdc
@@ -1,0 +1,228 @@
+import "FungibleToken"
+import "MetadataViews"
+import "FungibleTokenMetadataViews"
+
+import "TestTokenMinter"
+
+access(all) contract TokenC: FungibleToken {
+
+    /// The event that is emitted when new tokens are minted
+    access(all) event TokensMinted(amount: UFix64, type: String)
+
+    /// Total supply of TokenC in existence
+    access(all) var totalSupply: UFix64
+
+    /// Storage and Public Paths
+    access(all) let VaultStoragePath: StoragePath
+    access(all) let VaultPublicPath: PublicPath
+    access(all) let ReceiverPublicPath: PublicPath
+    access(all) let AdminStoragePath: StoragePath
+
+    access(all) view fun getContractViews(resourceType: Type?): [Type] {
+        return [
+            Type<FungibleTokenMetadataViews.FTView>(),
+            Type<FungibleTokenMetadataViews.FTDisplay>(),
+            Type<FungibleTokenMetadataViews.FTVaultData>(),
+            Type<FungibleTokenMetadataViews.TotalSupply>()
+        ]
+    }
+
+    access(all) fun resolveContractView(resourceType: Type?, viewType: Type): AnyStruct? {
+        switch viewType {
+            case Type<FungibleTokenMetadataViews.FTView>():
+                return FungibleTokenMetadataViews.FTView(
+                    ftDisplay: self.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTDisplay>()) as! FungibleTokenMetadataViews.FTDisplay?,
+                    ftVaultData: self.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+                )
+            case Type<FungibleTokenMetadataViews.FTDisplay>():
+                let media = MetadataViews.Media(
+                        file: MetadataViews.HTTPFile(
+                        url: "https://assets.website-files.com/5f6294c0c7a8cdd643b1c820/5f6294c0c7a8cda55cb1c936_Flow_Wordmark.svg"
+                    ),
+                    mediaType: "image/svg+xml"
+                )
+                let medias = MetadataViews.Medias([media])
+                return FungibleTokenMetadataViews.FTDisplay(
+                    name: "Example Fungible Token A",
+                    symbol: "A",
+                    description: "This fungible token is used as an example to help you develop your next FT #onFlow.",
+                    externalURL: MetadataViews.ExternalURL("https://example-ft.onflow.org"),
+                    logos: medias,
+                    socials: {
+                        "twitter": MetadataViews.ExternalURL("https://twitter.com/flow_blockchain")
+                    }
+                )
+            case Type<FungibleTokenMetadataViews.FTVaultData>():
+                return FungibleTokenMetadataViews.FTVaultData(
+                    storagePath: self.VaultStoragePath,
+                    receiverPath: self.ReceiverPublicPath,
+                    metadataPath: self.VaultPublicPath,
+                    receiverLinkedType: Type<&TokenC.Vault>(),
+                    metadataLinkedType: Type<&TokenC.Vault>(),
+                    createEmptyVaultFunction: (fun(): @{FungibleToken.Vault} {
+                        return <-TokenC.createEmptyVault(vaultType: Type<@TokenC.Vault>())
+                    })
+                )
+            case Type<FungibleTokenMetadataViews.TotalSupply>():
+                return FungibleTokenMetadataViews.TotalSupply(
+                    totalSupply: TokenC.totalSupply
+                )
+        }
+        return nil
+    }
+
+    /// Vault
+    ///
+    /// Each user stores an instance of only the Vault in their storage
+    /// The functions in the Vault and governed by the pre and post conditions
+    /// in FungibleToken when they are called.
+    /// The checks happen at runtime whenever a function is called.
+    ///
+    /// Resources can only be created in the context of the contract that they
+    /// are defined in, so there is no way for a malicious user to create Vaults
+    /// out of thin air. A special Minter resource needs to be defined to mint
+    /// new tokens.
+    ///
+    access(all) resource Vault: FungibleToken.Vault {
+
+        /// The total balance of this vault
+        access(all) var balance: UFix64
+
+        // initialize the balance at resource creation time
+        init(balance: UFix64) {
+            self.balance = balance
+        }
+
+        /// Called when a fungible token is burned via the `Burner.burn()` method
+        access(contract) fun burnCallback() {
+            if self.balance > 0.0 {
+                TokenC.totalSupply = TokenC.totalSupply - self.balance
+            }
+            self.balance = 0.0
+        }
+
+        /// In fungible tokens, there are no specific views for specific vaults,
+        /// So we can route calls to view functions to the contract views functions
+        access(all) view fun getViews(): [Type] {
+            return TokenC.getContractViews(resourceType: nil)
+        }
+
+        access(all) fun resolveView(_ view: Type): AnyStruct? {
+            return TokenC.resolveContractView(resourceType: nil, viewType: view)
+        }
+
+        /// getSupportedVaultTypes optionally returns a list of vault types that this receiver accepts
+        access(all) view fun getSupportedVaultTypes(): {Type: Bool} {
+            let supportedTypes: {Type: Bool} = {}
+            supportedTypes[self.getType()] = true
+            return supportedTypes
+        }
+
+        access(all) view fun isSupportedVaultType(type: Type): Bool {
+            return self.getSupportedVaultTypes()[type] ?? false
+        }
+
+        /// Asks if the amount can be withdrawn from this vault
+        access(all) view fun isAvailableToWithdraw(amount: UFix64): Bool {
+            return amount <= self.balance
+        }
+
+        /// withdraw
+        ///
+        /// Function that takes an amount as an argument
+        /// and withdraws that amount from the Vault.
+        ///
+        /// It creates a new temporary Vault that is used to hold
+        /// the tokens that are being transferred. It returns the newly
+        /// created Vault to the context that called so it can be deposited
+        /// elsewhere.
+        ///
+        access(FungibleToken.Withdraw) fun withdraw(amount: UFix64): @TokenC.Vault {
+            self.balance = self.balance - amount
+            return <-create Vault(balance: amount)
+        }
+
+        /// deposit
+        ///
+        /// Function that takes a Vault object as an argument and adds
+        /// its balance to the balance of the owners Vault.
+        ///
+        /// It is allowed to destroy the sent Vault because the Vault
+        /// was a temporary holder of the tokens. The Vault's balance has
+        /// been consumed and therefore can be destroyed.
+        ///
+        access(all) fun deposit(from: @{FungibleToken.Vault}) {
+            let vault <- from as! @TokenC.Vault
+            self.balance = self.balance + vault.balance
+            destroy vault
+        }
+
+        /// createEmptyVault
+        ///
+        /// Function that creates a new Vault with a balance of zero
+        /// and returns it to the calling context. A user must call this function
+        /// and store the returned Vault in their storage in order to allow their
+        /// account to be able to receive deposits of this token type.
+        ///
+        access(all) fun createEmptyVault(): @TokenC.Vault {
+            return <-create Vault(balance: 0.0)
+        }
+    }
+
+    /// Minter
+    ///
+    /// Resource object that token admin accounts can hold to mint new tokens.
+    ///
+    access(all) resource Minter : TestTokenMinter.Minter {
+        /// mintTokens
+        ///
+        /// Function that mints new tokens, adds them to the total supply,
+        /// and returns them to the calling context.
+        ///
+        access(all) fun mintTokens(amount: UFix64): @TokenC.Vault {
+            TokenC.totalSupply = TokenC.totalSupply + amount
+            let vault <-create Vault(balance: amount)
+            emit TokensMinted(amount: amount, type: vault.getType().identifier)
+            return <-vault
+        }
+    }
+
+    /// createEmptyVault
+    ///
+    /// Function that creates a new Vault with a balance of zero
+    /// and returns it to the calling context. A user must call this function
+    /// and store the returned Vault in their storage in order to allow their
+    /// account to be able to receive deposits of this token type.
+    ///
+    access(all) fun createEmptyVault(vaultType: Type): @TokenC.Vault {
+        return <- create Vault(balance: 0.0)
+    }
+
+    init() {
+        self.totalSupply = 1000.0
+
+        self.VaultStoragePath = /storage/tokenCVault
+        self.VaultPublicPath = /public/tokenCVault
+        self.ReceiverPublicPath = /public/tokenCReceiver
+        self.AdminStoragePath = /storage/tokenCAdmin 
+
+        // Create the Vault with the total supply of tokens and save it in storage
+        //
+        let vault <- create Vault(balance: self.totalSupply)
+        emit TokensMinted(amount: vault.balance, type: vault.getType().identifier)
+
+        // Create a public capability to the stored Vault that exposes
+        // the `deposit` method and getAcceptedTypes method through the `Receiver` interface
+        // and the `balance` method through the `Balance` interface
+        //
+        let tokenCCap = self.account.capabilities.storage.issue<&TokenC.Vault>(self.VaultStoragePath)
+        self.account.capabilities.publish(tokenCCap, at: self.VaultPublicPath)
+        let receiverCap = self.account.capabilities.storage.issue<&TokenC.Vault>(self.VaultStoragePath)
+        self.account.capabilities.publish(receiverCap, at: self.ReceiverPublicPath)
+
+        self.account.storage.save(<-vault, to: /storage/tokenCVault)
+
+        let admin <- create Minter()
+        self.account.storage.save(<-admin, to: self.AdminStoragePath)
+    }
+}

--- a/cadence/tests/scripts/sequential-swapper/mock_quote.cdc
+++ b/cadence/tests/scripts/sequential-swapper/mock_quote.cdc
@@ -1,0 +1,43 @@
+import "FungibleToken"
+
+import "DeFiActions"
+import "SwapConnectors"
+import "MockSwapper"
+
+access(all) fun main(
+    vaultHost: Address,
+    mockSwapperConfigs: [{String: AnyStruct}],
+    amount: UFix64,
+    out: Bool,
+    reverse: Bool
+): {DeFiActions.Quote} {
+    pre {
+        mockSwapperConfigs.length > 1: "Provided configs must have a length of at least 3 - provided \(mockSwapperConfigs.length) vaultIdentifiers"
+    }
+    let acct = getAuthAccount<auth(Storage, Capabilities) &Account>(vaultHost)
+    let swappers: [MockSwapper.Swapper] = []
+    for i, config in mockSwapperConfigs {
+        // cast all config data
+        let inVaultType = config["inVault"] as! Type
+        let outVaultType = config["outVault"] as! Type
+        let inVaultPath = config["inVaultPath"] as! StoragePath
+        let outVaultPath = config["outVaultPath"] as! StoragePath
+        let priceRatio = config["priceRatio"] as! UFix64
+
+        let inVaultCap = acct.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(inVaultPath)
+        let outVaultCap = acct.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(outVaultPath)
+
+        swappers.append(MockSwapper.Swapper(
+            inVault: inVaultType,
+            outVault: outVaultType,
+            inVaultSource: inVaultCap,
+            outVaultSource: outVaultCap,
+            priceRatio: priceRatio,
+            uniqueID: nil
+        ))
+    }
+    let seqSwapper = SwapConnectors.SequentialSwapper(swappers: swappers, uniqueID: nil)
+    return out
+        ? seqSwapper.quoteOut(forProvided: amount, reverse: reverse)
+        : seqSwapper.quoteIn(forDesired: amount, reverse: reverse)
+}

--- a/cadence/tests/scripts/sequential-swapper/mock_swap.cdc
+++ b/cadence/tests/scripts/sequential-swapper/mock_swap.cdc
@@ -1,0 +1,49 @@
+import "FungibleToken"
+
+import "SwapConnectors"
+import "MockSwapper"
+
+access(all) fun main(
+    vaultHost: Address,
+    mockSwapperConfigs: [{String: AnyStruct}],
+    amountIn: UFix64
+): UFix64 {
+    pre {
+        mockSwapperConfigs.length > 1: "Provided configs must have a length of at least 3 - provided \(mockSwapperConfigs.length) vaultIdentifiers"
+    }
+    let acct = getAuthAccount<auth(Storage, Capabilities) &Account>(vaultHost)
+    let swappers: [MockSwapper.Swapper] = []
+    var inVault: auth(FungibleToken.Withdraw) &{FungibleToken.Vault}? = nil
+    for i, config in mockSwapperConfigs {
+        // cast all config data
+        let inVaultType = config["inVault"] as! Type
+        let outVaultType = config["outVault"] as! Type
+        let inVaultPath = config["inVaultPath"] as! StoragePath
+        let outVaultPath = config["outVaultPath"] as! StoragePath
+        let priceRatio = config["priceRatio"] as! UFix64
+
+        let inVaultCap = acct.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(inVaultPath)
+        let outVaultCap = acct.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(outVaultPath)
+
+        if i == 0 {
+            inVault = inVaultCap.borrow() ?? panic("Invalid inVaultCap for \(inVaultType.identifier)")
+        }
+
+        swappers.append(MockSwapper.Swapper(
+            inVault: inVaultType,
+            outVault: outVaultType,
+            inVaultSource: inVaultCap,
+            outVaultSource: outVaultCap,
+            priceRatio: priceRatio,
+            uniqueID: nil
+        ))
+    }
+    let seqSwapper = SwapConnectors.SequentialSwapper(swappers: swappers, uniqueID: nil)
+
+    // perform swap
+    let swapped <- seqSwapper.swap(quote: nil, inVault: <-inVault!.withdraw(amount: amountIn))
+    let amountOut = swapped.balance
+    destroy swapped
+
+    return amountOut
+}

--- a/cadence/tests/scripts/sequential-swapper/mock_swap_back.cdc
+++ b/cadence/tests/scripts/sequential-swapper/mock_swap_back.cdc
@@ -1,0 +1,49 @@
+import "FungibleToken"
+
+import "SwapConnectors"
+import "MockSwapper"
+
+access(all) fun main(
+    vaultHost: Address,
+    mockSwapperConfigs: [{String: AnyStruct}],
+    amountIn: UFix64
+): UFix64 {
+    pre {
+        mockSwapperConfigs.length > 1: "Provided configs must have a length of at least 3 - provided \(mockSwapperConfigs.length) vaultIdentifiers"
+    }
+    let acct = getAuthAccount<auth(Storage, Capabilities) &Account>(vaultHost)
+    let swappers: [MockSwapper.Swapper] = []
+    var outVault: auth(FungibleToken.Withdraw) &{FungibleToken.Vault}? = nil
+    for i, config in mockSwapperConfigs {
+        // cast all config data
+        let inVaultType = config["inVault"] as! Type
+        let outVaultType = config["outVault"] as! Type
+        let inVaultPath = config["inVaultPath"] as! StoragePath
+        let outVaultPath = config["outVaultPath"] as! StoragePath
+        let priceRatio = config["priceRatio"] as! UFix64
+
+        let inVaultCap = acct.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(inVaultPath)
+        let outVaultCap = acct.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(outVaultPath)
+
+        if i == mockSwapperConfigs.length - 1 {
+            outVault = outVaultCap.borrow() ?? panic("Invalid outVaultCap for \(outVaultType.identifier)")
+        }
+
+        swappers.append(MockSwapper.Swapper(
+            inVault: inVaultType,
+            outVault: outVaultType,
+            inVaultSource: inVaultCap,
+            outVaultSource: outVaultCap,
+            priceRatio: priceRatio,
+            uniqueID: nil
+        ))
+    }
+    let seqSwapper = SwapConnectors.SequentialSwapper(swappers: swappers, uniqueID: nil)
+
+    // perform swap
+    let swapped <- seqSwapper.swapBack(quote: nil, residual: <-outVault!.withdraw(amount: amountIn))
+    let amountOut = swapped.balance
+    destroy swapped
+
+    return amountOut
+}

--- a/flow.json
+++ b/flow.json
@@ -90,6 +90,12 @@
 				"testing": "0000000000000009"
 			}
 		},
+		"MockSwapper": {
+			"source": "cadence/tests/contracts/MockSwapper.cdc",
+			"aliases": {
+				"testing": "0000000000000009"
+			}
+		},
 		"MockOracle": {
 			"source": "cadence/tests/contracts/MockOracle.cdc",
 			"aliases": {
@@ -116,6 +122,12 @@
 		},
 		"TokenB": {
 			"source": "cadence/tests/contracts/TokenB.cdc",
+			"aliases": {
+				"testing": "0000000000000010"
+			}
+		},
+		"TokenC": {
+			"source": "cadence/tests/contracts/TokenC.cdc",
 			"aliases": {
 				"testing": "0000000000000010"
 			}


### PR DESCRIPTION
### Description

- Add a Sequential Swapper enabling for customized swap paths across protocols and sub-swappers.