### PR TITLE
fix(UniswapV3): remove hardcoded slippage from swap execution

### DIFF
--- a/cadence/contracts/connectors/evm/UniswapV3SwapConnectors.cdc
+++ b/cadence/contracts/connectors/evm/UniswapV3SwapConnectors.cdc
@@ -515,10 +515,9 @@ access(all) contract UniswapV3SwapConnectors {
                 UniswapV3SwapConnectors._callError("approve(address,uint256)", res, inToken, idType, id, self.getType())
             }
 
-            // Slippage/min out on EVM units (adjust factor to your policy)
-            let slippage = 0.01 // 1%
+            // Min out on EVM units
             let minOutUint = FlowEVMBridgeUtils.convertCadenceAmountToERC20Amount(
-                amountOutMin * (1.0 - slippage),
+                amountOutMin,
                 erc20Address: outToken
             )
 


### PR DESCRIPTION
## Summary

Removes the hardcoded 1% slippage adjustment from the UniswapV3 swap connector.

## Changes

- Remove unused `slippage` variable (was set to `0.01` / 1%)
- Use `amountOutMin` directly without additional slippage adjustment
- Slippage should be handled at the caller level, not inside the swap connector

## Rationale

The swap connector was applying an extra 1% slippage on top of whatever minimum output amount was passed in. This double-slippage behavior was incorrect - the caller should have full control over the minimum acceptable output amount.