### PR TITLE
FLOW-7-fix(ERC4626): allow swap to exhaust full sink capacity

### DIFF
--- a/cadence/contracts/connectors/evm/ERC4626SwapConnectors.cdc
+++ b/cadence/contracts/connectors/evm/ERC4626SwapConnectors.cdc
@@ -186,7 +186,6 @@ access(all) contract ERC4626SwapConnectors {
 
             // deposit the inVault into the asset sink
             self.assetSink.depositCapacity(from: &inVault as auth(FungibleToken.Withdraw) &{FungibleToken.Vault})
-            assert(self.assetSink.minimumCapacity() > 0.0, message: "Expected ERC4626 Asset Sink to have capacity after depositing")
             Burner.burn(<-inVault)
 
             // get the after available shares


### PR DESCRIPTION
Remove overly restrictive assertion that prevented exhausting full capacity. The swap operation remains valid as long as shares increased after the deposit.