### PR TITLE
FLOW-3-fix(ERC4626): use correct COA address for maxDeposit check in quoteOut

### DIFF
--- a/cadence/contracts/connectors/evm/ERC4626SwapConnectors.cdc
+++ b/cadence/contracts/connectors/evm/ERC4626SwapConnectors.cdc
@@ -142,12 +142,13 @@ access(all) contract ERC4626SwapConnectors {
                 )
             }
             
-            // ensure the provided amount is not greater than the maximum deposit amount
-            let uintMaxDeposit = ERC4626Utils.maxDeposit(vault: self.vault, receiver: self.assetEVMAddress)
+            // ensure the provided amount is not greater than the maximum deposit capacity
+            let maxCapacity = self.assetSink.minimumCapacity()
             var _forProvided = forProvided
-            if uintMaxDeposit != nil {
-                let ufixMaxDeposit = FlowEVMBridgeUtils.convertERC20AmountToCadenceAmount(uintMaxDeposit!, erc20Address: self.assetEVMAddress)
-                _forProvided = _forProvided > ufixMaxDeposit ? ufixMaxDeposit : _forProvided
+            if maxCapacity == 0.0 {
+                _forProvided = 0.0
+            } else if _forProvided > maxCapacity {
+                _forProvided = maxCapacity
             }
             let uintForProvided = FlowEVMBridgeUtils.convertCadenceAmountToERC20Amount(_forProvided, erc20Address: self.assetEVMAddress)
 


### PR DESCRIPTION
Use assetSink.minimumCapacity() which internally calls maxDeposit with the correct COA address instead of the asset token contract address.