### PR TITLE
FLOW-S2-fix(ERC4626): validate ofToken parameter in price oracle

### DIFF
--- a/cadence/contracts/connectors/evm/ERC4626PriceOracles.cdc
+++ b/cadence/contracts/connectors/evm/ERC4626PriceOracles.cdc
@@ -59,10 +59,17 @@ access(all) contract ERC4626PriceOracles {
         }
         /// Returns the current price of the ERC4626 vault denominated in the underlying asset type
         ///
-        /// @param ofToken The token type to get the price of
+        /// @param ofToken The ERC4626 share token type to get the price of
         ///
         /// @return The current price of the ERC4626 vault denominated in the underlying asset type
         access(all) fun price(ofToken: Type): UFix64? {
+            if let vaultType = FlowEVMBridgeConfig.getTypeAssociated(with: self.vault) {
+                if ofToken != vaultType {
+                    return nil
+                }
+            } else {
+                return nil
+            }
             let totalAssets = ERC4626Utils.totalAssets(vault: self.vault)
             let totalShares = ERC4626Utils.totalShares(vault: self.vault)
             if totalAssets == nil || totalShares == nil || totalShares == UInt256(0) {

--- a/cadence/scripts/erc4626-price-oracles/price.cdc
+++ b/cadence/scripts/erc4626-price-oracles/price.cdc
@@ -1,4 +1,5 @@
 import "EVM"
+import "FlowEVMBridgeConfig"
 
 import "ERC4626PriceOracles"
 
@@ -6,10 +7,12 @@ access(all)
 fun main(vaultHex: String, assetIdentifier: String): UFix64? {
     let vault = EVM.addressFromString(vaultHex)
     let asset = CompositeType(assetIdentifier) ?? panic("Invalid asset identifier: \(assetIdentifier)")
+    let shareType = FlowEVMBridgeConfig.getTypeAssociated(with: vault)
+        ?? panic("Invalid vault address \(vaultHex) - no associated Cadence type found")
     let oracle = ERC4626PriceOracles.PriceOracle(
         vault: vault,
         asset: asset,
         uniqueID: nil
     )
-    return oracle.price(ofToken: asset)
+    return oracle.price(ofToken: shareType)
 }


### PR DESCRIPTION
Return nil from PriceOracle.price(ofToken:) unless ofToken equals the expected share token type for the oracle. Previously the function ignored the ofToken parameter and always returned the price of the configured vault, which could mask integration bugs.