### PR TITLE
Add IncrementFi price oracle

### DIFF
--- a/cadence/scripts/increment-fi-adapters/get_price.cdc
+++ b/cadence/scripts/increment-fi-adapters/get_price.cdc
@@ -1,0 +1,19 @@
+import "DeFiActions"
+import "IncrementFiSwapConnectors"
+
+access(all)
+fun main(
+    unitOfAccountIdentifier: String,
+    baseTokenIdentifier: String,
+    path: [String],
+    ofTokenIdentifier: String
+): UFix64? {
+    let oracle = IncrementFiSwapConnectors.PriceOracle(
+        unitOfAccount: CompositeType(unitOfAccountIdentifier) ?? panic("Invalid unitOfAccount \(unitOfAccountIdentifier)"),
+        baseToken: CompositeType(baseTokenIdentifier) ?? panic("Invalid baseToken \(baseTokenIdentifier)"),
+        path: path,
+        uniqueID: nil
+    )
+    let ofToken = CompositeType(ofTokenIdentifier) ?? panic("Invalid ofToken \(ofTokenIdentifier)")
+    return oracle.price(ofToken: ofToken)
+}

--- a/cadence/tests/IncrementFiSwapConnectors_test.cdc
+++ b/cadence/tests/IncrementFiSwapConnectors_test.cdc
@@ -120,3 +120,25 @@ fun testAdapterGetAmountsOutSucceeds() {
     let quote = amountsOutRes.returnValue! as! {DeFiActions.Quote}
     Test.assertEqual(inAmount, quote.inAmount)
 }
+
+access(all)
+fun testPriceOracleGetPrice() {
+    let path = [tokenAKey, tokenBKey]
+    let priceOfBaseRes = executeScript(
+        "../scripts/increment-fi-adapters/get_price.cdc",
+        [tokenBIdentifier, tokenAIdentifier, path, tokenAIdentifier]
+    )
+    Test.expect(priceOfBaseRes, Test.beSucceeded())
+    let priceOfBase = priceOfBaseRes.returnValue as! UFix64?
+    Test.assert(priceOfBase != nil, message: "Price of base token should be non-nil")
+    Test.assert(priceOfBase! > 0.0, message: "Price of base token should be positive")
+    log(priceOfBase!)
+    let priceOfQuoteRes = executeScript(
+        "../scripts/increment-fi-adapters/get_price.cdc",
+        [tokenBIdentifier, tokenAIdentifier, path, tokenBIdentifier]
+    )
+    Test.expect(priceOfQuoteRes, Test.beSucceeded())
+    let priceOfQuote = priceOfQuoteRes.returnValue
+    Test.assert(priceOfQuote != nil, message: "Price of quote token should be non-nil")
+    Test.assertEqual(priceOfQuote, 1.0 as UFix64?)
+}

--- a/flow.json
+++ b/flow.json
@@ -217,7 +217,7 @@
 		"ArrayUtils": {
 			"source": "mainnet://1e4aa0b87d10b141.ArrayUtils",
 			"hash": "e70ddc2f0c7c72158a3f6c68de3a131e1f49e2908ad83eac0308f9e2953957d5",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -228,7 +228,7 @@
 		"BandOracle": {
 			"source": "mainnet://6801a6222ebf784a.BandOracle",
 			"hash": "ababa195ef50b63d71520022aa2468656a9703b924c0f5228cfaa51a71db094d",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "6801a6222ebf784a",
 				"mainnet-fork": "6801a6222ebf784a",
@@ -239,7 +239,7 @@
 		"Burner": {
 			"source": "mainnet://f233dcee88fe0abe.Burner",
 			"hash": "71af18e227984cd434a3ad00bb2f3618b76482842bae920ee55662c37c8bf331",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "f233dcee88fe0abe",
@@ -250,7 +250,7 @@
 		"CrossVMMetadataViews": {
 			"source": "mainnet://1d7e57aa55817448.CrossVMMetadataViews",
 			"hash": "7e79b77b87c750de5b126ebd6fca517c2b905ac7f01c0428e9f3f82838c7f524",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
@@ -261,7 +261,7 @@
 		"CrossVMNFT": {
 			"source": "mainnet://1e4aa0b87d10b141.CrossVMNFT",
 			"hash": "8fe69f487164caffedab68b52a584fa7aa4d54a0061f4f211998c73a619fbea5",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -272,7 +272,7 @@
 		"CrossVMToken": {
 			"source": "mainnet://1e4aa0b87d10b141.CrossVMToken",
 			"hash": "9f055ad902e7de5619a2b0f2dc91826ac9c4f007afcd6df9f5b8229c0ca94531",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -283,7 +283,7 @@
 		"EVM": {
 			"source": "mainnet://e467b9dd11fa00df.EVM",
 			"hash": "960b0c7df7ee536956af196fba8c8d5dd4f7a89a4ecc61467e31287c4617b0dd",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
@@ -294,7 +294,7 @@
 		"FlowEVMBridge": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridge",
 			"hash": "9cd0f897b19c0394e9042225e5758d6ae529a0cce19b19ae05bde8e0f14aa10b",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -305,7 +305,7 @@
 		"FlowEVMBridgeAccessor": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeAccessor",
 			"hash": "888ba0aab5e961924c47b819f4a9f410449c39745e0d3eab20738bf10ef2ed0f",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -316,7 +316,7 @@
 		"FlowEVMBridgeConfig": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeConfig",
 			"hash": "3c09f74467f22dac7bc02b2fdf462213b2f8ddfb513cd890ad0c2a7016507be3",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -327,7 +327,7 @@
 		"FlowEVMBridgeCustomAssociationTypes": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeCustomAssociationTypes",
 			"hash": "4651183c3f04f8c5faaa35106b3ab66060ce9868590adb33f3be1900c12ea196",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -338,7 +338,7 @@
 		"FlowEVMBridgeCustomAssociations": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeCustomAssociations",
 			"hash": "14d1f4ddd347f45d331e543830b94701e1aa1513c56d55c0019c7fac46d8a572",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -349,7 +349,7 @@
 		"FlowEVMBridgeHandlerInterfaces": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeHandlerInterfaces",
 			"hash": "e32154f2a556e53328a0fce75f1e98b57eefd2a8cb626e803b7d39d452691444",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -360,7 +360,7 @@
 		"FlowEVMBridgeHandlers": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeHandlers",
 			"hash": "7e8adff1dca0ea1d2e361c17de9eca020f82cabc00a52679078752bf85adb004",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -371,7 +371,7 @@
 		"FlowEVMBridgeNFTEscrow": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeNFTEscrow",
 			"hash": "30257592838edfd4b72700f43bf0326f6903e879f82ac5ca549561d9863c6fe6",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -382,7 +382,7 @@
 		"FlowEVMBridgeResolver": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeResolver",
 			"hash": "c1ac18e92828616771df5ff5d6de87866f2742ca4ce196601c11e977e4f63bb3",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -393,7 +393,7 @@
 		"FlowEVMBridgeTemplates": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeTemplates",
 			"hash": "78b8115eb0ef2be4583acbe655f0c5128c39712084ec23ce47820ea154141898",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -404,7 +404,7 @@
 		"FlowEVMBridgeTokenEscrow": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeTokenEscrow",
 			"hash": "49df9c8e5d0dd45abd5bf94376d3b9045299b3c2a5ba6caf48092c916362358d",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -415,7 +415,7 @@
 		"FlowEVMBridgeUtils": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeUtils",
 			"hash": "634ed6dde03eb8f027368aa7861889ce1f5099160903493a7a39a86c9afea14b",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -426,7 +426,7 @@
 		"FlowFees": {
 			"source": "mainnet://f919ee77447b7497.FlowFees",
 			"hash": "341cc0f3cc847d6b787c390133f6a5e6c867c111784f09c5c0083c47f2f1df64",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "e5a8b7f23e8b548f",
 				"mainnet": "f919ee77447b7497",
@@ -437,7 +437,7 @@
 		"FlowStorageFees": {
 			"source": "mainnet://e467b9dd11fa00df.FlowStorageFees",
 			"hash": "a92c26fb2ea59725441fa703aa4cd811e0fc56ac73d649a8e12c1e72b67a8473",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
@@ -448,7 +448,7 @@
 		"FlowToken": {
 			"source": "mainnet://1654653399040a61.FlowToken",
 			"hash": "f82389e2412624ffa439836b00b42e6605b0c00802a4e485bc95b8930a7eac38",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "0ae53cb6e3f42a79",
 				"mainnet": "1654653399040a61",
@@ -459,7 +459,7 @@
 		"FlowTransactionScheduler": {
 			"source": "mainnet://e467b9dd11fa00df.FlowTransactionScheduler",
 			"hash": "23157cf7d70534e45b0ab729133232d0ffb3cdae52661df1744747cb1f8c0495",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
@@ -470,7 +470,7 @@
 		"FlowTransactionSchedulerUtils": {
 			"source": "mainnet://e467b9dd11fa00df.FlowTransactionSchedulerUtils",
 			"hash": "71a1febab6b9ba76abec36dab1e61b1c377e44fbe627e5fac649deb71b727877",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "e467b9dd11fa00df"
 			}
@@ -478,7 +478,7 @@
 		"FungibleToken": {
 			"source": "mainnet://f233dcee88fe0abe.FungibleToken",
 			"hash": "4b74edfe7d7ddfa70b703c14aa731a0b2e7ce016ce54d998bfd861ada4d240f6",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
 				"mainnet": "f233dcee88fe0abe",
@@ -489,7 +489,7 @@
 		"FungibleTokenMetadataViews": {
 			"source": "mainnet://f233dcee88fe0abe.FungibleTokenMetadataViews",
 			"hash": "70477f80fd7678466c224507e9689f68f72a9e697128d5ea54d19961ec856b3c",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
 				"mainnet": "f233dcee88fe0abe",
@@ -500,7 +500,7 @@
 		"FungibleTokenSwitchboard": {
 			"source": "mainnet://f233dcee88fe0abe.FungibleTokenSwitchboard",
 			"hash": "eeb0a352911efeaca2051e10a13e866016ab075e3c9b6c16d539198d6f64d84c",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
 				"mainnet": "f233dcee88fe0abe",
@@ -511,7 +511,7 @@
 		"IBridgePermissions": {
 			"source": "mainnet://1e4aa0b87d10b141.IBridgePermissions",
 			"hash": "431a51a6cca87773596f79832520b19499fe614297eaef347e49383f2ae809af",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -522,7 +522,7 @@
 		"ICrossVM": {
 			"source": "mainnet://1e4aa0b87d10b141.ICrossVM",
 			"hash": "b95c36eef516da7cd4d2f507cd48288cc16b1d6605ff03b6fcd18161ff2d82e7",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -533,7 +533,7 @@
 		"ICrossVMAsset": {
 			"source": "mainnet://1e4aa0b87d10b141.ICrossVMAsset",
 			"hash": "d9c7b2bd9fdcc454180c33b3509a5a060a7fe4bd49bce38818f22fd08acb8ba0",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -544,7 +544,7 @@
 		"IEVMBridgeNFTMinter": {
 			"source": "mainnet://1e4aa0b87d10b141.IEVMBridgeNFTMinter",
 			"hash": "e2ad15c495ad7fbf4ab744bccaf8c4334dfb843b50f09e9681ce9a5067dbf049",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -555,7 +555,7 @@
 		"IEVMBridgeTokenMinter": {
 			"source": "mainnet://1e4aa0b87d10b141.IEVMBridgeTokenMinter",
 			"hash": "0ef39c6cb476f0eea2c835900b6a5a83c1ed5f4dbaaeb29cb68ad52c355a40e6",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -566,7 +566,7 @@
 		"IFlowEVMNFTBridge": {
 			"source": "mainnet://1e4aa0b87d10b141.IFlowEVMNFTBridge",
 			"hash": "2d495e896510a10bbc7307739aca9341633cac4c7fe7dad32488a81f90a39dd9",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -577,7 +577,7 @@
 		"IFlowEVMTokenBridge": {
 			"source": "mainnet://1e4aa0b87d10b141.IFlowEVMTokenBridge",
 			"hash": "87f7d752da8446e73acd3bf4aa17fe5c279d9641b7976c56561af01bc5240ea4",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -587,6 +587,8 @@
 		},
 		"MOET": {
 			"source": "mainnet://6b00ff876c299c61.MOET",
+			"hash": "45dc87539777207f4a6a9230ba2f218f0adc05819b0a4e7f707f2299f0abf16b",
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "6b00ff876c299c61",
 				"mainnet-fork": "6b00ff876c299c61",
@@ -596,7 +598,7 @@
 		"MetadataViews": {
 			"source": "mainnet://1d7e57aa55817448.MetadataViews",
 			"hash": "b290b7906d901882b4b62e596225fb2f10defb5eaaab4a09368f3aee0e9c18b1",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
@@ -607,7 +609,7 @@
 		"NonFungibleToken": {
 			"source": "mainnet://1d7e57aa55817448.NonFungibleToken",
 			"hash": "a258de1abddcdb50afc929e74aca87161d0083588f6abf2b369672e64cf4a403",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
@@ -618,7 +620,7 @@
 		"ScopedFTProviders": {
 			"source": "mainnet://1e4aa0b87d10b141.ScopedFTProviders",
 			"hash": "77213f9588ec9862d07c4706689424ad7c1d8f043d5970d96bf18764bb936fc3",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -629,7 +631,7 @@
 		"Serialize": {
 			"source": "mainnet://1e4aa0b87d10b141.Serialize",
 			"hash": "064bb0d7b6c24ee1ed370cbbe9e0cda2a4e0955247de5e3e81f2f3a8a8cabfb7",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -640,7 +642,7 @@
 		"SerializeMetadata": {
 			"source": "mainnet://1e4aa0b87d10b141.SerializeMetadata",
 			"hash": "e9f84ea07e29cae05ee0d9264596eb281c291fc1090a10ce3de1a042b4d671da",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -651,7 +653,7 @@
 		"StableSwapFactory": {
 			"source": "mainnet://b063c16cac85dbd1.StableSwapFactory",
 			"hash": "a63b57a5cc91085016abc34c1b49622b385a8f976ac2ba0e646f7a3f780d344e",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "b063c16cac85dbd1",
 				"mainnet-fork": "b063c16cac85dbd1",
@@ -662,7 +664,7 @@
 		"Staking": {
 			"source": "mainnet://1b77ba4b414de352.Staking",
 			"hash": "276bcfcd986e09e65fa744691941eb6761dd45e4d748e5c3ef539b2942bb4041",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1b77ba4b414de352",
 				"mainnet-fork": "1b77ba4b414de352",
@@ -673,7 +675,7 @@
 		"StakingError": {
 			"source": "mainnet://1b77ba4b414de352.StakingError",
 			"hash": "f76be3a19f8b640149fa0860316a34058b96c4ac2154486e337fd449306c730e",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1b77ba4b414de352",
 				"mainnet-fork": "1b77ba4b414de352",
@@ -684,7 +686,7 @@
 		"StringUtils": {
 			"source": "mainnet://1e4aa0b87d10b141.StringUtils",
 			"hash": "28ac1a744ac7fb97253cba007a520a9ec1c2e14458d1bd1add1424fa19282c03",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "1e4aa0b87d10b141",
 				"mainnet-fork": "1e4aa0b87d10b141",
@@ -695,7 +697,7 @@
 		"SwapConfig": {
 			"source": "mainnet://b78ef7afa52ff906.SwapConfig",
 			"hash": "111f3caa0ab506bed100225a1481f77687f6ac8493d97e49f149fa26a174ef99",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "b78ef7afa52ff906",
 				"mainnet-fork": "b78ef7afa52ff906",
@@ -706,7 +708,7 @@
 		"SwapError": {
 			"source": "mainnet://b78ef7afa52ff906.SwapError",
 			"hash": "7d13a652a1308af387513e35c08b4f9a7389a927bddf08431687a846e4c67f21",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "b78ef7afa52ff906",
 				"mainnet-fork": "b78ef7afa52ff906",
@@ -717,7 +719,7 @@
 		"SwapFactory": {
 			"source": "mainnet://b063c16cac85dbd1.SwapFactory",
 			"hash": "deea03edbb49877c8c72276e1911cf87bdba4052ae9c3ac54c0d4ac62f3ef511",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "b063c16cac85dbd1",
 				"mainnet-fork": "b063c16cac85dbd1",
@@ -728,7 +730,7 @@
 		"SwapInterfaces": {
 			"source": "mainnet://b78ef7afa52ff906.SwapInterfaces",
 			"hash": "e559dff4d914fa12fff7ba482f30d3c575dc3d31587833fd628763d1a4ee96b2",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "b78ef7afa52ff906",
 				"mainnet-fork": "b78ef7afa52ff906",
@@ -739,7 +741,7 @@
 		"SwapPair": {
 			"source": "mainnet://ecbda466e7f191c7.SwapPair",
 			"hash": "d908a3c2643007da0519da0c4780c39e26c0b879d1c20bc143fb98d998c754c5",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "ecbda466e7f191c7",
 				"mainnet-fork": "ecbda466e7f191c7",
@@ -750,7 +752,7 @@
 		"SwapRouter": {
 			"source": "mainnet://a6850776a94e6551.SwapRouter",
 			"hash": "c0365c01978ca32af94602bfddd0796cfe6375e60a05b927b5de539e608baec5",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"mainnet": "a6850776a94e6551",
 				"mainnet-fork": "a6850776a94e6551",
@@ -761,7 +763,7 @@
 		"ViewResolver": {
 			"source": "mainnet://1d7e57aa55817448.ViewResolver",
 			"hash": "374a1994046bac9f6228b4843cb32393ef40554df9bd9907a702d098a2987bde",
-			"block_height": 140486614,
+			"block_height": 143586532,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
@@ -880,14 +882,6 @@
 				"resourceID": "projects/flow-foundation-admin/locations/global/keyRings/defi-actions/cryptoKeys/mainnet-defi-actions/cryptoKeyVersions/1"
 			}
 		},
-		"testnet-morpho-erc4626-connectors": {
-			"address": "71144a1aff6b7148",
-			"key": {
-				"type": "google-kms",
-				"hashAlgorithm": "SHA2_256",
-				"resourceID": "projects/flow-foundation-admin/locations/global/keyRings/defi-actions/cryptoKeys/testnet-defi-actions/cryptoKeyVersions/1"
-			}
-		},
 		"mainnet-originator": {
 			"address": "0e9374d0c1a78c0f",
 			"key": {
@@ -969,6 +963,14 @@
 		},
 		"testnet-increment-fi-connectors": {
 			"address": "494536c102537e1e",
+			"key": {
+				"type": "google-kms",
+				"hashAlgorithm": "SHA2_256",
+				"resourceID": "projects/flow-foundation-admin/locations/global/keyRings/defi-actions/cryptoKeys/testnet-defi-actions/cryptoKeyVersions/1"
+			}
+		},
+		"testnet-morpho-erc4626-connectors": {
+			"address": "71144a1aff6b7148",
 			"key": {
 				"type": "google-kms",
 				"hashAlgorithm": "SHA2_256",
@@ -1131,10 +1133,6 @@
 			"testnet-evm-amount-utils": [
 				"EVMAmountUtils"
 			],
-			"testnet-morpho-erc4626-connectors": [
-				"MorphoERC4626SwapConnectors",
-				"MorphoERC4626SinkConnectors"
-			],
 			"testnet-evm-token-connectors": [
 				"EVMNativeFLOWConnectors",
 				"EVMTokenConnectors"
@@ -1147,6 +1145,10 @@
 				"IncrementFiSwapConnectors",
 				"IncrementFiPoolLiquidityConnectors",
 				"IncrementFiStakingConnectors"
+			],
+			"testnet-morpho-erc4626-connectors": [
+				"MorphoERC4626SwapConnectors",
+				"MorphoERC4626SinkConnectors"
 			],
 			"testnet-swap-connectors": [
 				"SwapConnectors"


### PR DESCRIPTION
This PR introduces the PriceOracle implementation for IncrementFi Swap, which is a requirement for integrating with the FlowALP oracle aggregator.

By using IncrementFi’s SwapRouter, we can derive real-time spot prices for token pairs.