### PR TITLE
Restore MultiSwapper backcompat semantics

### DIFF
--- a/cadence/contracts/connectors/SwapConnectors.cdc
+++ b/cadence/contracts/connectors/SwapConnectors.cdc
@@ -146,82 +146,42 @@ access(all) contract SwapConnectors {
         access(all) view fun outType(): Type  {
             return self.outVault
         }
-        /// The estimated amount required to provide a Vault with the desired output balance.
-        ///
-        /// Selection policy (two-tier):
-        ///   1. Full-coverage routes (outAmount >= forDesired): prefer minimum inAmount
-        ///   2. Partial-coverage routes (outAmount < forDesired, pool capped): prefer maximum outAmount
-        /// Full-coverage always wins over partial-coverage regardless of inAmount.
+        /// The estimated amount required to provide a Vault with the desired output balance
         access(all) fun quoteIn(forDesired: UFix64, reverse: Bool): {DeFiActions.Quote} {
-            var hasFull = false
-            var bestIdx = 0
-            var bestInAmount = UFix64.max
-            var bestOutAmount = 0.0
-            var partialIdx = 0
-            var partialInAmount = 0.0
-            var partialOutAmount = 0.0
-
-            for i in InclusiveRange(0, self.swappers.length - 1) {
-                let quote = (&self.swappers[i] as &{DeFiActions.Swapper})
-                    .quoteIn(forDesired: forDesired, reverse: reverse)
-                if quote.inAmount == 0.0 || quote.outAmount == 0.0 { continue }
-
-                if quote.outAmount >= forDesired {
-                    // full coverage — prefer minimum inAmount
-                    if !hasFull || quote.inAmount < bestInAmount {
-                        hasFull = true
-                        bestIdx = i
-                        bestInAmount = quote.inAmount
-                        bestOutAmount = quote.outAmount
-                    }
-                } else if !hasFull {
-                    // partial coverage — prefer maximum outAmount (only when no full route found)
-                    if quote.outAmount > partialOutAmount {
-                        partialIdx = i
-                        partialInAmount = quote.inAmount
-                        partialOutAmount = quote.outAmount
-                    }
-                }
+            if let estimate = self._estimate(amount: forDesired, out: false, reverse: reverse) {
+                return MultiSwapperQuote(
+                    inType: estimate.inType,
+                    outType: estimate.outType,
+                    inAmount: estimate.inAmount,
+                    outAmount: estimate.outAmount >= forDesired ? forDesired : estimate.outAmount,
+                    swapperIndex: estimate.swapperIndex
+                )
             }
-
-            let idx = hasFull ? bestIdx : partialIdx
-            let inAmt = hasFull ? bestInAmount : partialInAmount
-            let outAmt = hasFull ? bestOutAmount : partialOutAmount
             return MultiSwapperQuote(
                 inType: reverse ? self.outType() : self.inType(),
                 outType: reverse ? self.inType() : self.outType(),
-                inAmount: inAmt,
-                outAmount: outAmt,
-                swapperIndex: idx
+                inAmount: 0.0,
+                outAmount: 0.0,
+                swapperIndex: 0
             )
         }
-        /// The estimated amount delivered out for a provided input balance.
-        ///
-        /// Selection policy: prefer maximum outAmount across all routes.
+        /// The estimated amount delivered out for a provided input balance
         access(all) fun quoteOut(forProvided: UFix64, reverse: Bool): {DeFiActions.Quote} {
-            var hasBest = false
-            var bestIdx = 0
-            var bestInAmount = forProvided
-            var bestOutAmount = 0.0
-
-            for i in InclusiveRange(0, self.swappers.length - 1) {
-                let quote = (&self.swappers[i] as &{DeFiActions.Swapper})
-                    .quoteOut(forProvided: forProvided, reverse: reverse)
-                if quote.inAmount == 0.0 || quote.outAmount == 0.0 { continue }
-                if !hasBest || quote.outAmount > bestOutAmount {
-                    hasBest = true
-                    bestIdx = i
-                    bestInAmount = quote.inAmount
-                    bestOutAmount = quote.outAmount
-                }
+            if let estimate = self._estimate(amount: forProvided, out: true, reverse: reverse) {
+                return MultiSwapperQuote(
+                    inType: estimate.inType,
+                    outType: estimate.outType,
+                    inAmount: forProvided,
+                    outAmount: estimate.outAmount,
+                    swapperIndex: estimate.swapperIndex
+                )
             }
-
             return MultiSwapperQuote(
                 inType: reverse ? self.outType() : self.inType(),
                 outType: reverse ? self.inType() : self.outType(),
-                inAmount: bestInAmount,
-                outAmount: bestOutAmount,
-                swapperIndex: bestIdx
+                inAmount: 0.0,
+                outAmount: 0.0,
+                swapperIndex: 0
             )
         }
         /// Performs a swap taking a Vault of type inVault, outputting a resulting outVault. Implementations may choose
@@ -238,6 +198,57 @@ access(all) contract SwapConnectors {
         /// NOTE: providing a Quote does not guarantee the fulfilled swap will enforce the quote's defined outAmount
         access(all) fun swapBack(quote: {DeFiActions.Quote}?, residual: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
             return <-self._swap(quote: quote, from: <-residual, reverse: true)
+        }
+        /// Returns the winning route's full quote metadata.
+        ///
+        /// For quoteOut, this maximizes outAmount across all routes.
+        /// For quoteIn, full-coverage routes win over partial routes, and among
+        /// full-coverage routes the minimum inAmount is preferred.
+        access(self) fun _estimate(amount: UFix64, out: Bool, reverse: Bool): MultiSwapperQuote? {
+            var best: MultiSwapperQuote? = nil
+            var bestPartial: MultiSwapperQuote? = nil
+            for i in InclusiveRange(0, self.swappers.length - 1) {
+                let swapper = &self.swappers[i] as &{DeFiActions.Swapper}
+                let quote = out
+                    ? swapper.quoteOut(forProvided: amount, reverse: reverse)
+                    : swapper.quoteIn(forDesired: amount, reverse: reverse)
+
+                // Treat conventionally unavailable quotes as unusable.
+                if quote.inAmount == 0.0 || quote.outAmount == 0.0 {
+                    continue
+                }
+
+                let estimate = MultiSwapperQuote(
+                    inType: reverse ? self.outType() : self.inType(),
+                    outType: reverse ? self.inType() : self.outType(),
+                    inAmount: quote.inAmount,
+                    outAmount: quote.outAmount,
+                    swapperIndex: i
+                )
+
+                if out {
+                    if best == nil || best!.outAmount < estimate.outAmount {
+                        best = estimate
+                    }
+                    continue
+                }
+
+                if estimate.outAmount >= amount {
+                    if best == nil || estimate.inAmount < best!.inAmount {
+                        best = estimate
+                    }
+                } else if best == nil {
+                    if bestPartial == nil
+                        || bestPartial!.outAmount < estimate.outAmount
+                        || (
+                            bestPartial!.outAmount == estimate.outAmount
+                            && estimate.inAmount < bestPartial!.inAmount
+                        ) {
+                        bestPartial = estimate
+                    }
+                }
+            }
+            return best ?? bestPartial
         }
         /// Swaps the provided Vault in the defined direction. If the quote is not a MultiSwapperQuote, a new quote is
         /// requested and the current optimal Swapper used to fulfill the swap.

--- a/cadence/tests/SwapConnectorsMultiSwapper_test.cdc
+++ b/cadence/tests/SwapConnectorsMultiSwapper_test.cdc
@@ -18,19 +18,28 @@ fun transferFlow(signer: Test.TestAccount, recipient: Address, amount: UFix64) {
     Test.expect(Test.executeTransaction(txn), Test.beSucceeded())
 }
 
-// inVault: TokenA, outVault: TokenB — shared across all multi-swapper tests
-access(all) let inVaultType  = Type<@TokenA.Vault>()
+access(all)
+fun runTransaction(path: String, signer: Test.TestAccount, arguments: [AnyStruct]): Test.TransactionResult {
+    let txn = Test.Transaction(
+        code: Test.readFile(path),
+        authorizers: [signer.address],
+        signers: [signer],
+        arguments: arguments
+    )
+    return Test.executeTransaction(txn)
+}
+
+access(all) let inVaultType = Type<@TokenA.Vault>()
 access(all) let outVaultType = Type<@TokenB.Vault>()
 
-/// Returns a CapLimitedSwapper config using TokenA → TokenB vaults.
 access(all) fun makeConfig(priceRatio: UFix64, maxOut: UFix64): {String: AnyStruct} {
     return {
-        "inVault":     inVaultType,
-        "outVault":    outVaultType,
+        "inVault": inVaultType,
+        "outVault": outVaultType,
         "inVaultPath": TokenA.VaultStoragePath,
         "outVaultPath": TokenB.VaultStoragePath,
-        "priceRatio":  priceRatio,
-        "maxOut":      maxOut
+        "priceRatio": priceRatio,
+        "maxOut": maxOut
     }
 }
 
@@ -57,12 +66,6 @@ fun setup() {
     transferFlow(signer: serviceAccount, recipient: testTokenAccount.address, amount: 10.0)
 }
 
-/// quoteIn — among two full-coverage routes, the one with the lower inAmount wins.
-///
-/// Swapper 0: priceRatio=0.5 → inAmount = 10.0/0.5 = 20.0  (expensive, full coverage)
-/// Swapper 1: priceRatio=0.8 → inAmount = 10.0/0.8 = 12.5  (cheaper, full coverage)
-/// Expected: index 1, inAmount=12.5, outAmount=10.0
-///
 access(all)
 fun testQuoteInPreferMinInAmongFullCoverage() {
     let forDesired = 10.0
@@ -81,17 +84,10 @@ fun testQuoteInPreferMinInAmongFullCoverage() {
     Test.assertEqual(1, quote.swapperIndex)
     Test.assertEqual(10.0 / 0.8, quote.inAmount)
     Test.assertEqual(forDesired, quote.outAmount)
-    Test.assertEqual(inVaultType,  quote.inType)
+    Test.assertEqual(inVaultType, quote.inType)
     Test.assertEqual(outVaultType, quote.outType)
 }
 
-/// quoteIn — a full-coverage route wins over a partial-coverage route even when the partial
-/// route has a lower inAmount.
-///
-/// Swapper 0: priceRatio=1.0, maxOut=5.0  → partial (outAmount=5.0 < 10.0), inAmount=5.0
-/// Swapper 1: priceRatio=0.5, maxOut=100.0 → full   (outAmount=10.0),        inAmount=20.0
-/// Expected: index 1 (full coverage wins despite higher inAmount)
-///
 access(all)
 fun testQuoteInFullWinsOverPartial() {
     let forDesired = 10.0
@@ -108,15 +104,10 @@ fun testQuoteInFullWinsOverPartial() {
     let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
 
     Test.assertEqual(1, quote.swapperIndex)
+    Test.assertEqual(20.0, quote.inAmount)
     Test.assertEqual(forDesired, quote.outAmount)
 }
 
-/// quoteIn — when no full-coverage route exists, the partial route with the highest outAmount wins.
-///
-/// Swapper 0: priceRatio=0.8, maxOut=3.0 → partial (outAmount=3.0)
-/// Swapper 1: priceRatio=1.0, maxOut=7.0 → partial (outAmount=7.0)
-/// Expected: index 1 (higher outAmount among partials)
-///
 access(all)
 fun testQuoteInPartialFallbackMaxOut() {
     let forDesired = 10.0
@@ -134,15 +125,9 @@ fun testQuoteInPartialFallbackMaxOut() {
 
     Test.assertEqual(1, quote.swapperIndex)
     Test.assertEqual(7.0, quote.outAmount)
-    Test.assertEqual(7.0, quote.inAmount) // 7.0 / priceRatio=1.0
+    Test.assertEqual(7.0, quote.inAmount)
 }
 
-/// quoteOut — the route with the highest outAmount wins.
-///
-/// Swapper 0: priceRatio=0.5, maxOut=100.0 → outAmount=5.0
-/// Swapper 1: priceRatio=0.8, maxOut=100.0 → outAmount=8.0
-/// Expected: index 1 (higher outAmount)
-///
 access(all)
 fun testQuoteOutPreferMaxOut() {
     let forProvided = 10.0
@@ -159,24 +144,79 @@ fun testQuoteOutPreferMaxOut() {
     let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
 
     Test.assertEqual(1, quote.swapperIndex)
+    Test.assertEqual(forProvided, quote.inAmount)
     Test.assertEqual(10.0 * 0.8, quote.outAmount)
-    Test.assertEqual(inVaultType,  quote.inType)
-    Test.assertEqual(outVaultType, quote.outType)
 }
 
-/// quoteOut — a cap constraint causes a higher-ratio route to deliver less output than a
-/// lower-ratio uncapped route, so the uncapped route wins.
-///
-/// Swapper 0: priceRatio=0.5, maxOut=100.0 → outAmount=5.0  (uncapped)
-/// Swapper 1: priceRatio=0.9, maxOut=4.0   → rawOut=9.0, capped to 4.0
-/// Expected: index 0 (outAmount=5.0 > 4.0 after cap)
-///
 access(all)
-fun testQuoteOutCapLimitsRoute() {
+fun testQuoteInReversePreferMinInAmongFullCoverage() {
+    let forDesired = 10.0
+    let configs = [
+        makeConfig(priceRatio: 0.8, maxOut: 100.0),
+        makeConfig(priceRatio: 0.5, maxOut: 100.0)
+    ]
+
+    let result = executeScript(
+        "./scripts/multi-swapper/mock_quote_in.cdc",
+        [testTokenAccount.address, configs, inVaultType, outVaultType, forDesired, true]
+    )
+    Test.expect(result, Test.beSucceeded())
+    let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
+
+    Test.assertEqual(1, quote.swapperIndex)
+    Test.assertEqual(5.0, quote.inAmount)
+    Test.assertEqual(forDesired, quote.outAmount)
+    Test.assertEqual(outVaultType, quote.inType)
+    Test.assertEqual(inVaultType, quote.outType)
+}
+
+access(all)
+fun testQuoteOutReversePreferMaxOut() {
     let forProvided = 10.0
     let configs = [
-        makeConfig(priceRatio: 0.5, maxOut: 100.0),
-        makeConfig(priceRatio: 0.9, maxOut: 4.0)
+        makeConfig(priceRatio: 0.8, maxOut: 100.0),
+        makeConfig(priceRatio: 0.5, maxOut: 100.0)
+    ]
+
+    let result = executeScript(
+        "./scripts/multi-swapper/mock_quote_out.cdc",
+        [testTokenAccount.address, configs, inVaultType, outVaultType, forProvided, true]
+    )
+    Test.expect(result, Test.beSucceeded())
+    let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
+
+    Test.assertEqual(1, quote.swapperIndex)
+    Test.assertEqual(forProvided, quote.inAmount)
+    Test.assertEqual(20.0, quote.outAmount)
+    Test.assertEqual(outVaultType, quote.inType)
+    Test.assertEqual(inVaultType, quote.outType)
+}
+
+access(all)
+fun testQuoteInPartialTieBreaksOnLowerInAmount() {
+    let forDesired = 10.0
+    let configs = [
+        makeConfig(priceRatio: 0.5, maxOut: 5.0),
+        makeConfig(priceRatio: 1.0, maxOut: 5.0)
+    ]
+
+    let result = executeScript(
+        "./scripts/multi-swapper/mock_quote_in.cdc",
+        [testTokenAccount.address, configs, inVaultType, outVaultType, forDesired, false]
+    )
+    Test.expect(result, Test.beSucceeded())
+    let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
+
+    Test.assertEqual(1, quote.swapperIndex)
+    Test.assertEqual(5.0, quote.inAmount)
+    Test.assertEqual(5.0, quote.outAmount)
+}
+
+access(all)
+fun testQuoteOutPreservesProvidedInputOnCappedRoute() {
+    let forProvided = 10.0
+    let configs = [
+        makeConfig(priceRatio: 1.0, maxOut: 4.0)
     ]
 
     let result = executeScript(
@@ -187,5 +227,26 @@ fun testQuoteOutCapLimitsRoute() {
     let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
 
     Test.assertEqual(0, quote.swapperIndex)
-    Test.assertEqual(5.0, quote.outAmount) // 10.0 * 0.5
+    Test.assertEqual(forProvided, quote.inAmount)
+    Test.assertEqual(4.0, quote.outAmount)
+}
+
+access(all)
+fun testSwapWithQuoteOutFallbackSucceedsAgainstStrictInnerSwapper() {
+    let result = runTransaction(
+        path: "./transactions/multi-swapper/mock_strict_swap_quote_out.cdc",
+        signer: testTokenAccount,
+        arguments: [10.0, 1.0, 4.0]
+    )
+    Test.expect(result, Test.beSucceeded())
+}
+
+access(all)
+fun testSwapSourceWithdrawAvailableDoesNotExceedMaxAmount() {
+    let result = runTransaction(
+        path: "./transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc",
+        signer: testTokenAccount,
+        arguments: [10.0, 1.0]
+    )
+    Test.expect(result, Test.beSucceeded())
 }

--- a/cadence/tests/contracts/MockSwapper.cdc
+++ b/cadence/tests/contracts/MockSwapper.cdc
@@ -200,4 +200,182 @@ access(all) contract MockSwapper {
         access(contract) view fun copyID(): DeFiActions.UniqueIdentifier? { return self.uniqueID }
         access(contract) fun setID(_ id: DeFiActions.UniqueIdentifier?) { self.uniqueID = id }
     }
+
+    /// TEST-ONLY strict capacity-limited swapper. Behaves like CapLimitedSwapper, but
+    /// also enforces that swaps do not exceed quote.inAmount.
+    access(all) struct StrictCapLimitedSwapper : DeFiActions.Swapper {
+        access(self) let inVault: Type
+        access(self) let outVault: Type
+        access(self) let inVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>
+        access(self) let outVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>
+        access(self) let priceRatio: UFix64
+        access(self) let maxOut: UFix64
+        access(contract) var uniqueID: DeFiActions.UniqueIdentifier?
+
+        init(
+            inVault: Type,
+            outVault: Type,
+            inVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>,
+            outVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>,
+            priceRatio: UFix64,
+            maxOut: UFix64,
+            uniqueID: DeFiActions.UniqueIdentifier?
+        ) {
+            pre {
+                inVault.isSubtype(of: Type<@{FungibleToken.Vault}>()): "inVault must be a FungibleToken Vault"
+                outVault.isSubtype(of: Type<@{FungibleToken.Vault}>()): "outVault must be a FungibleToken Vault"
+                inVaultSource.check(): "Invalid inVaultSource capability"
+                outVaultSource.check(): "Invalid outVaultSource capability"
+                priceRatio > 0.0: "Invalid price ratio"
+                maxOut > 0.0: "Invalid maxOut"
+            }
+            self.inVault = inVault
+            self.outVault = outVault
+            self.inVaultSource = inVaultSource
+            self.outVaultSource = outVaultSource
+            self.priceRatio = priceRatio
+            self.maxOut = maxOut
+            self.uniqueID = uniqueID
+        }
+
+        access(all) view fun inType(): Type { return self.inVault }
+        access(all) view fun outType(): Type { return self.outVault }
+
+        access(all) fun quoteIn(forDesired: UFix64, reverse: Bool): {DeFiActions.Quote} {
+            let actualOut = forDesired > self.maxOut ? self.maxOut : forDesired
+            let inAmt = reverse ? actualOut * self.priceRatio : actualOut / self.priceRatio
+            return BasicQuote(
+                inType: reverse ? self.outType() : self.inType(),
+                outType: reverse ? self.inType() : self.outType(),
+                inAmount: inAmt,
+                outAmount: actualOut
+            )
+        }
+
+        access(all) fun quoteOut(forProvided: UFix64, reverse: Bool): {DeFiActions.Quote} {
+            let rawOut = reverse ? forProvided / self.priceRatio : forProvided * self.priceRatio
+            let actualOut = rawOut > self.maxOut ? self.maxOut : rawOut
+            let actualIn = reverse ? actualOut * self.priceRatio : actualOut / self.priceRatio
+            return BasicQuote(
+                inType: reverse ? self.outType() : self.inType(),
+                outType: reverse ? self.inType() : self.outType(),
+                inAmount: actualIn,
+                outAmount: actualOut
+            )
+        }
+
+        access(all) fun swap(quote: {DeFiActions.Quote}?, inVault: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+            pre { inVault.getType() == self.inType(): "Wrong in type \(inVault.getType().identifier) - expected \(self.inType().identifier)" }
+            let appliedQuote = quote ?? self.quoteOut(forProvided: inVault.balance, reverse: false)
+            assert(inVault.balance <= appliedQuote.inAmount, message: "Swap input exceeds quote.inAmount")
+
+            let depositTo = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            depositTo.deposit(from: <-inVault)
+
+            let src = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            return <- src.withdraw(amount: appliedQuote.outAmount)
+        }
+
+        access(all) fun swapBack(quote: {DeFiActions.Quote}?, residual: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+            pre { residual.getType() == self.outType(): "Wrong out type \(residual.getType().identifier) - expected \(self.outType().identifier)" }
+            let appliedQuote = quote ?? self.quoteOut(forProvided: residual.balance, reverse: true)
+            assert(residual.balance <= appliedQuote.inAmount, message: "SwapBack input exceeds quote.inAmount")
+
+            let depositTo = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            depositTo.deposit(from: <-residual)
+
+            let src = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            return <- src.withdraw(amount: appliedQuote.outAmount)
+        }
+
+        access(all) fun getComponentInfo(): DeFiActions.ComponentInfo {
+            return DeFiActions.ComponentInfo(type: self.getType(), id: self.id(), innerComponents: [])
+        }
+        access(contract) view fun copyID(): DeFiActions.UniqueIdentifier? { return self.uniqueID }
+        access(contract) fun setID(_ id: DeFiActions.UniqueIdentifier?) { self.uniqueID = id }
+    }
+
+    /// TEST-ONLY swapper that returns a quoteIn outAmount above the requested amount.
+    access(all) struct QuoteInOvershootSwapper : DeFiActions.Swapper {
+        access(self) let inVault: Type
+        access(self) let outVault: Type
+        access(self) let inVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>
+        access(self) let outVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>
+        access(self) let priceRatio: UFix64
+        access(self) let quoteInOvershoot: UFix64
+        access(contract) var uniqueID: DeFiActions.UniqueIdentifier?
+
+        init(
+            inVault: Type,
+            outVault: Type,
+            inVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>,
+            outVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>,
+            priceRatio: UFix64,
+            quoteInOvershoot: UFix64,
+            uniqueID: DeFiActions.UniqueIdentifier?
+        ) {
+            pre {
+                inVault.isSubtype(of: Type<@{FungibleToken.Vault}>()): "inVault must be a FungibleToken Vault"
+                outVault.isSubtype(of: Type<@{FungibleToken.Vault}>()): "outVault must be a FungibleToken Vault"
+                inVaultSource.check(): "Invalid inVaultSource capability"
+                outVaultSource.check(): "Invalid outVaultSource capability"
+                priceRatio > 0.0: "Invalid price ratio"
+                quoteInOvershoot >= 0.0: "Invalid quoteInOvershoot"
+            }
+            self.inVault = inVault
+            self.outVault = outVault
+            self.inVaultSource = inVaultSource
+            self.outVaultSource = outVaultSource
+            self.priceRatio = priceRatio
+            self.quoteInOvershoot = quoteInOvershoot
+            self.uniqueID = uniqueID
+        }
+
+        access(all) view fun inType(): Type { return self.inVault }
+        access(all) view fun outType(): Type { return self.outVault }
+
+        access(all) fun quoteIn(forDesired: UFix64, reverse: Bool): {DeFiActions.Quote} {
+            let inAmt = reverse ? forDesired * self.priceRatio : forDesired / self.priceRatio
+            return BasicQuote(
+                inType: reverse ? self.outType() : self.inType(),
+                outType: reverse ? self.inType() : self.outType(),
+                inAmount: inAmt,
+                outAmount: forDesired + self.quoteInOvershoot
+            )
+        }
+
+        access(all) fun quoteOut(forProvided: UFix64, reverse: Bool): {DeFiActions.Quote} {
+            let outAmt = reverse ? forProvided / self.priceRatio : forProvided * self.priceRatio
+            return BasicQuote(
+                inType: reverse ? self.outType() : self.inType(),
+                outType: reverse ? self.inType() : self.outType(),
+                inAmount: forProvided,
+                outAmount: outAmt
+            )
+        }
+
+        access(all) fun swap(quote: {DeFiActions.Quote}?, inVault: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+            pre { inVault.getType() == self.inType(): "Wrong in type \(inVault.getType().identifier) - expected \(self.inType().identifier)" }
+            let outAmt = (quote?.outAmount) ?? (inVault.balance * self.priceRatio)
+            let depositTo = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            depositTo.deposit(from: <-inVault)
+            let src = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            return <- src.withdraw(amount: outAmt)
+        }
+
+        access(all) fun swapBack(quote: {DeFiActions.Quote}?, residual: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+            pre { residual.getType() == self.outType(): "Wrong out type \(residual.getType().identifier) - expected \(self.outType().identifier)" }
+            let inAmt = (quote?.inAmount) ?? (residual.balance / self.priceRatio)
+            let depositTo = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            depositTo.deposit(from: <-residual)
+            let src = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            return <- src.withdraw(amount: inAmt)
+        }
+
+        access(all) fun getComponentInfo(): DeFiActions.ComponentInfo {
+            return DeFiActions.ComponentInfo(type: self.getType(), id: self.id(), innerComponents: [])
+        }
+        access(contract) view fun copyID(): DeFiActions.UniqueIdentifier? { return self.uniqueID }
+        access(contract) fun setID(_ id: DeFiActions.UniqueIdentifier?) { self.uniqueID = id }
+    }
 }

--- a/cadence/tests/transactions/multi-swapper/mock_strict_swap_quote_out.cdc
+++ b/cadence/tests/transactions/multi-swapper/mock_strict_swap_quote_out.cdc
@@ -1,0 +1,52 @@
+import "FungibleToken"
+
+import "TokenA"
+import "TokenB"
+
+import "DeFiActions"
+import "SwapConnectors"
+import "MockSwapper"
+
+transaction(amountIn: UFix64, priceRatio: UFix64, maxOut: UFix64) {
+    let tokenBReceiver: &{FungibleToken.Receiver}
+    let multiSwapper: SwapConnectors.MultiSwapper
+    let expectedOut: UFix64
+    let inVault: @{FungibleToken.Vault}
+
+    prepare(signer: auth(Storage, Capabilities, BorrowValue) &Account) {
+        let tokenAVault = signer.storage.borrow<auth(FungibleToken.Withdraw) &TokenA.Vault>(from: TokenA.VaultStoragePath)
+            ?? panic("Missing TokenA vault")
+        self.tokenBReceiver = signer.capabilities.borrow<&{FungibleToken.Receiver}>(TokenB.ReceiverPublicPath)
+            ?? panic("Missing TokenB receiver")
+
+        self.inVault <- tokenAVault.withdraw(amount: amountIn)
+
+        let inCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenA.VaultStoragePath)
+        let outCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenB.VaultStoragePath)
+
+        self.multiSwapper = SwapConnectors.MultiSwapper(
+            inVault: Type<@TokenA.Vault>(),
+            outVault: Type<@TokenB.Vault>(),
+            swappers: [
+                MockSwapper.StrictCapLimitedSwapper(
+                    inVault: Type<@TokenA.Vault>(),
+                    outVault: Type<@TokenB.Vault>(),
+                    inVaultSource: inCap,
+                    outVaultSource: outCap,
+                    priceRatio: priceRatio,
+                    maxOut: maxOut,
+                    uniqueID: nil
+                )
+            ],
+            uniqueID: nil
+        )
+
+        self.expectedOut = amountIn * priceRatio > maxOut ? maxOut : amountIn * priceRatio
+    }
+
+    execute {
+        let outVault <- self.multiSwapper.swap(quote: nil, inVault: <-self.inVault)
+        assert(outVault.balance == self.expectedOut, message: "Unexpected output amount")
+        self.tokenBReceiver.deposit(from: <-outVault)
+    }
+}

--- a/cadence/tests/transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc
+++ b/cadence/tests/transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc
@@ -1,0 +1,57 @@
+import "FungibleToken"
+
+import "TokenA"
+import "TokenB"
+
+import "DeFiActions"
+import "FungibleTokenConnectors"
+import "SwapConnectors"
+import "MockSwapper"
+
+transaction(maxAmount: UFix64, quoteInOvershoot: UFix64) {
+    let swapSource: SwapConnectors.SwapSource
+    let tokenBReceiver: &{FungibleToken.Receiver}
+
+    prepare(signer: auth(Storage, Capabilities, BorrowValue) &Account) {
+        self.tokenBReceiver = signer.capabilities.borrow<&{FungibleToken.Receiver}>(TokenB.ReceiverPublicPath)
+            ?? panic("Missing TokenB receiver")
+
+        let inCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenA.VaultStoragePath)
+        let outCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenB.VaultStoragePath)
+
+        let source = FungibleTokenConnectors.VaultSource(
+            min: nil,
+            withdrawVault: inCap,
+            uniqueID: nil
+        )
+
+        let multiSwapper = SwapConnectors.MultiSwapper(
+            inVault: Type<@TokenA.Vault>(),
+            outVault: Type<@TokenB.Vault>(),
+            swappers: [
+                MockSwapper.QuoteInOvershootSwapper(
+                    inVault: Type<@TokenA.Vault>(),
+                    outVault: Type<@TokenB.Vault>(),
+                    inVaultSource: inCap,
+                    outVaultSource: outCap,
+                    priceRatio: 1.0,
+                    quoteInOvershoot: quoteInOvershoot,
+                    uniqueID: nil
+                )
+            ],
+            uniqueID: nil
+        )
+
+        self.swapSource = SwapConnectors.SwapSource(
+            swapper: multiSwapper,
+            source: source,
+            uniqueID: nil
+        )
+    }
+
+    execute {
+        let outVault <- self.swapSource.withdrawAvailable(maxAmount: maxAmount)
+        assert(outVault.balance == maxAmount, message: "SwapSource withdrawAvailable exceeded maxAmount")
+        self.tokenBReceiver.deposit(from: <-outVault)
+    }
+}


### PR DESCRIPTION
## What changed

This keeps the route-picking fix from `#158`, but restores the old `MultiSwapper` quote shape that other code already expects.

- `quoteIn(forDesired)` still returns at most `forDesired`
- `quoteOut(forProvided)` still returns `inAmount = forProvided`
- `_estimate` still uses the full inner quote to pick the best route

## Why

`#158` fixed the original route-selection bug, but it also changed the public quote values returned by `MultiSwapper`.

That caused two new problems:

1. `swap(nil, ...)` could fail with strict or capped inner swappers
2. `SwapSource.withdrawAvailable(maxAmount)` could return more than `maxAmount`

This PR keeps the better route selection, but brings back the old public behavior so those callers keep working.

## Tests

- `flow test ./cadence/tests/SwapConnectorsMultiSwapper_test.cdc`
