### PR TITLE
Fix MultiSwapper quote backcompat

### DIFF
--- a/cadence/contracts/connectors/SwapConnectors.cdc
+++ b/cadence/contracts/connectors/SwapConnectors.cdc
@@ -146,88 +146,42 @@ access(all) contract SwapConnectors {
         access(all) view fun outType(): Type  {
             return self.outVault
         }
-        /// The estimated amount required to provide a Vault with the desired output balance.
-        ///
-        /// Swapper quotes are divided into two groups:
-        /// 1. Full group: the pool has enough liquidity to fully fulfill forDesired
-        /// 2. Partial group: the pool can only fulfill part of forDesired
-        ///
-        /// Selection policy:
-        /// - If any swapper is in the full group, return the one with the lowest inAmount
-        /// - Otherwise, return the partial group quote with the highest outAmount (best liquidity),
-        ///   even if it doesn't have the best rate
+        /// The estimated amount required to provide a Vault with the desired output balance
         access(all) fun quoteIn(forDesired: UFix64, reverse: Bool): {DeFiActions.Quote} {
-            var hasFull = false
-            var bestIdx = 0
-            var bestInAmount = UFix64.max
-            var bestOutAmount = 0.0
-
-            for i in InclusiveRange(0, self.swappers.length - 1) {
-                let quote = (&self.swappers[i] as &{DeFiActions.Swapper})
-                    .quoteIn(forDesired: forDesired, reverse: reverse)
-                if quote.inAmount == 0.0 || quote.outAmount == 0.0 { continue }
-
-                if quote.outAmount >= forDesired {
-                    // full coverage group - comparing between swappers that can full fulfill the forDesire,
-                    // in this case we prefer the quote with minimum inAmount
-                    if !hasFull || quote.inAmount < bestInAmount {
-                        // when hasFull == false, we can skip the second check, because 
-                        // there is no bestInAmount yet, this quote itself will be the best temporarily 
-                        // when hasFull == true, we compare with the previously best quote, if this 
-                        // quote has lower inAmount, then it's better.
-                        hasFull = true
-                        bestIdx = i
-                        bestInAmount = quote.inAmount
-                        bestOutAmount = quote.outAmount
-                    }
-                } else if !hasFull {
-                    // partial coverage group (only when no full route found)
-                    // in this case, prefer maximum outAmount 
-                    if quote.outAmount > bestOutAmount {
-                        bestIdx = i
-                        bestInAmount = quote.inAmount
-                        bestOutAmount = quote.outAmount
-                    }
-                }
+            if let estimate = self._estimate(amount: forDesired, out: false, reverse: reverse) {
+                return MultiSwapperQuote(
+                    inType: estimate.inType,
+                    outType: estimate.outType,
+                    inAmount: estimate.inAmount,
+                    outAmount: estimate.outAmount >= forDesired ? forDesired : estimate.outAmount,
+                    swapperIndex: estimate.swapperIndex
+                )
             }
-
             return MultiSwapperQuote(
                 inType: reverse ? self.outType() : self.inType(),
                 outType: reverse ? self.inType() : self.outType(),
-                inAmount: bestInAmount,
-                outAmount: bestOutAmount,
-                swapperIndex: bestIdx
+                inAmount: 0.0,
+                outAmount: 0.0,
+                swapperIndex: 0
             )
         }
-        /// The estimated amount delivered out for a provided input balance.
-        ///
-        /// Selection policy: prefer maximum outAmount across all routes.
+        /// The estimated amount delivered out for a provided input balance
         access(all) fun quoteOut(forProvided: UFix64, reverse: Bool): {DeFiActions.Quote} {
-            var bestIdx = 0
-            var bestInAmount = forProvided
-            var bestOutAmount = 0.0
-
-            for i in InclusiveRange(0, self.swappers.length - 1) {
-                let quote = (&self.swappers[i] as &{DeFiActions.Swapper})
-                    .quoteOut(forProvided: forProvided, reverse: reverse)
-                if quote.inAmount == 0.0 || quote.outAmount == 0.0 { continue }
-                if quote.outAmount > bestOutAmount {
-                    bestIdx = i
-                    bestOutAmount = quote.outAmount
-                    bestInAmount = quote.inAmount
-                } else if quote.outAmount == bestOutAmount && quote.inAmount < bestInAmount {
-                    bestIdx = i
-                    bestInAmount = quote.inAmount
-                    bestOutAmount = quote.outAmount
-                }
+            if let estimate = self._estimate(amount: forProvided, out: true, reverse: reverse) {
+                return MultiSwapperQuote(
+                    inType: estimate.inType,
+                    outType: estimate.outType,
+                    inAmount: forProvided,
+                    outAmount: estimate.outAmount,
+                    swapperIndex: estimate.swapperIndex
+                )
             }
-
             return MultiSwapperQuote(
                 inType: reverse ? self.outType() : self.inType(),
                 outType: reverse ? self.inType() : self.outType(),
-                inAmount: bestInAmount,
-                outAmount: bestOutAmount,
-                swapperIndex: bestIdx
+                inAmount: 0.0,
+                outAmount: 0.0,
+                swapperIndex: 0
             )
         }
         /// Performs a swap taking a Vault of type inVault, outputting a resulting outVault. Implementations may choose
@@ -236,16 +190,72 @@ access(all) contract SwapConnectors {
         /// requested and the optimal Swapper used to fulfill the swap.
         /// NOTE: providing a Quote does not guarantee the fulfilled swap will enforce the quote's defined outAmount
         access(all) fun swap(quote: {DeFiActions.Quote}?, inVault: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
-            let ensuredQuote = quote != nil ? quote : self.quoteOut(forProvided: inVault.balance, reverse: false)
-            return <-self._swap(quote: ensuredQuote, from: <-inVault, reverse: false)
+            return <-self._swap(quote: quote, from: <-inVault, reverse: false)
         }
         /// Performs a swap taking a Vault of type outVault, outputting a resulting inVault. Implementations may choose
         /// to swap along a pre-set path or an optimal path of a set of paths or even set of contained Swappers adapted
         /// to use multiple Flow swap protocols.
         /// NOTE: providing a Quote does not guarantee the fulfilled swap will enforce the quote's defined outAmount
         access(all) fun swapBack(quote: {DeFiActions.Quote}?, residual: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
-            let ensureQuote = quote != nil ? quote : self.quoteOut(forProvided: residual.balance, reverse: true)
-            return <-self._swap(quote: ensureQuote, from: <-residual, reverse: true)
+            return <-self._swap(quote: quote, from: <-residual, reverse: true)
+        }
+        /// Returns the winning route's full quote metadata.
+        ///
+        /// For quoteOut, this maximizes outAmount across all routes and prefers
+        /// the lower inAmount when outAmount ties.
+        /// For quoteIn, full-coverage routes win over partial routes, and among
+        /// routes with equal outAmount the lower inAmount is preferred.
+        access(self) fun _estimate(amount: UFix64, out: Bool, reverse: Bool): MultiSwapperQuote? {
+            var best: MultiSwapperQuote? = nil
+            var bestPartial: MultiSwapperQuote? = nil
+
+            for i in InclusiveRange(0, self.swappers.length - 1) {
+                let swapper = &self.swappers[i] as &{DeFiActions.Swapper}
+                let quote = out
+                    ? swapper.quoteOut(forProvided: amount, reverse: reverse)
+                    : swapper.quoteIn(forDesired: amount, reverse: reverse)
+
+                if quote.inAmount == 0.0 || quote.outAmount == 0.0 {
+                    continue
+                }
+
+                let estimate = MultiSwapperQuote(
+                    inType: reverse ? self.outType() : self.inType(),
+                    outType: reverse ? self.inType() : self.outType(),
+                    inAmount: quote.inAmount,
+                    outAmount: quote.outAmount,
+                    swapperIndex: i
+                )
+
+                if out {
+                    if best == nil
+                        || best!.outAmount < estimate.outAmount
+                        || (
+                            best!.outAmount == estimate.outAmount
+                            && estimate.inAmount < best!.inAmount
+                        ) {
+                        best = estimate
+                    }
+                    continue
+                }
+
+                if estimate.outAmount >= amount {
+                    if best == nil || estimate.inAmount < best!.inAmount {
+                        best = estimate
+                    }
+                } else if best == nil {
+                    if bestPartial == nil
+                        || bestPartial!.outAmount < estimate.outAmount
+                        || (
+                            bestPartial!.outAmount == estimate.outAmount
+                            && estimate.inAmount < bestPartial!.inAmount
+                        ) {
+                        bestPartial = estimate
+                    }
+                }
+            }
+
+            return best ?? bestPartial
         }
         /// Swaps the provided Vault in the defined direction. If the quote is not a MultiSwapperQuote, a new quote is
         /// requested and the current optimal Swapper used to fulfill the swap.

--- a/cadence/contracts/connectors/SwapConnectors.cdc
+++ b/cadence/contracts/connectors/SwapConnectors.cdc
@@ -186,7 +186,9 @@ access(all) contract SwapConnectors {
 
             let idx = hasFull ? bestIdx : partialIdx
             let inAmt = hasFull ? bestInAmount : partialInAmount
-            let outAmt = hasFull ? bestOutAmount : partialOutAmount
+            let outAmt = hasFull
+                ? (bestOutAmount > forDesired ? forDesired : bestOutAmount)
+                : partialOutAmount
             return MultiSwapperQuote(
                 inType: reverse ? self.outType() : self.inType(),
                 outType: reverse ? self.inType() : self.outType(),
@@ -201,7 +203,6 @@ access(all) contract SwapConnectors {
         access(all) fun quoteOut(forProvided: UFix64, reverse: Bool): {DeFiActions.Quote} {
             var hasBest = false
             var bestIdx = 0
-            var bestInAmount = forProvided
             var bestOutAmount = 0.0
 
             for i in InclusiveRange(0, self.swappers.length - 1) {
@@ -211,7 +212,6 @@ access(all) contract SwapConnectors {
                 if !hasBest || quote.outAmount > bestOutAmount {
                     hasBest = true
                     bestIdx = i
-                    bestInAmount = quote.inAmount
                     bestOutAmount = quote.outAmount
                 }
             }
@@ -219,7 +219,7 @@ access(all) contract SwapConnectors {
             return MultiSwapperQuote(
                 inType: reverse ? self.outType() : self.inType(),
                 outType: reverse ? self.inType() : self.outType(),
-                inAmount: bestInAmount,
+                inAmount: hasBest ? forProvided : 0.0,
                 outAmount: bestOutAmount,
                 swapperIndex: bestIdx
             )

--- a/cadence/contracts/connectors/SwapConnectors.cdc
+++ b/cadence/contracts/connectors/SwapConnectors.cdc
@@ -195,7 +195,7 @@ access(all) contract SwapConnectors {
                 inType: reverse ? self.outType() : self.inType(),
                 outType: reverse ? self.inType() : self.outType(),
                 inAmount: bestInAmount,
-                outAmount: bestOutAmount > forDesired ? forDesired : bestOutAmount,
+                outAmount: bestOutAmount,
                 swapperIndex: bestIdx
             )
         }
@@ -204,6 +204,7 @@ access(all) contract SwapConnectors {
         /// Selection policy: prefer maximum outAmount across all routes.
         access(all) fun quoteOut(forProvided: UFix64, reverse: Bool): {DeFiActions.Quote} {
             var bestIdx = 0
+            var bestInAmount = forProvided
             var bestOutAmount = 0.0
 
             for i in InclusiveRange(0, self.swappers.length - 1) {
@@ -213,6 +214,7 @@ access(all) contract SwapConnectors {
                 if quote.outAmount > bestOutAmount {
                     bestIdx = i
                     bestOutAmount = quote.outAmount
+                    bestInAmount = quote.inAmount
                 } else if quote.outAmount == bestOutAmount && quote.inAmount < bestInAmount {
                     bestIdx = i
                     bestInAmount = quote.inAmount
@@ -223,7 +225,7 @@ access(all) contract SwapConnectors {
             return MultiSwapperQuote(
                 inType: reverse ? self.outType() : self.inType(),
                 outType: reverse ? self.inType() : self.outType(),
-                inAmount: hasBest ? forProvided : 0.0,
+                inAmount: bestInAmount,
                 outAmount: bestOutAmount,
                 swapperIndex: bestIdx
             )
@@ -234,14 +236,16 @@ access(all) contract SwapConnectors {
         /// requested and the optimal Swapper used to fulfill the swap.
         /// NOTE: providing a Quote does not guarantee the fulfilled swap will enforce the quote's defined outAmount
         access(all) fun swap(quote: {DeFiActions.Quote}?, inVault: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
-            return <-self._swap(quote: quote, from: <-inVault, reverse: false)
+            let ensuredQuote = quote != nil ? quote : self.quoteOut(forProvided: inVault.balance, reverse: false)
+            return <-self._swap(quote: ensuredQuote, from: <-inVault, reverse: false)
         }
         /// Performs a swap taking a Vault of type outVault, outputting a resulting inVault. Implementations may choose
         /// to swap along a pre-set path or an optimal path of a set of paths or even set of contained Swappers adapted
         /// to use multiple Flow swap protocols.
         /// NOTE: providing a Quote does not guarantee the fulfilled swap will enforce the quote's defined outAmount
         access(all) fun swapBack(quote: {DeFiActions.Quote}?, residual: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
-            return <-self._swap(quote: quote, from: <-residual, reverse: true)
+            let ensureQuote = quote != nil ? quote : self.quoteOut(forProvided: residual.balance, reverse: true)
+            return <-self._swap(quote: ensureQuote, from: <-residual, reverse: true)
         }
         /// Swaps the provided Vault in the defined direction. If the quote is not a MultiSwapperQuote, a new quote is
         /// requested and the current optimal Swapper used to fulfill the swap.

--- a/cadence/contracts/interfaces/DeFiActions.cdc
+++ b/cadence/contracts/interfaces/DeFiActions.cdc
@@ -344,18 +344,26 @@ access(all) contract DeFiActions {
         access(all) view fun inType(): Type
         /// The type of Vault this Swapper provides when performing a swap
         access(all) view fun outType(): Type
-        /// Provides a quote for how many input tokens can be swapped for `forDesired` output tokens.
-        /// The reverse flag simply inverts inType/outType and inAmount/outAmount in the quote.
+        /// Provides a quote for the input and output amounts in the requested swap direction.
+        /// The reverse flag inverts the quoted token types, but quote.inAmount and quote.outAmount
+        /// always describe the amount of quote.inType provided for the amount of quote.outType
+        /// received.
         /// Interpretation:
-        /// - reverse=false -> I want to provide `quote.inAmount` input tokens and receive `forDesired` output tokens.
-        /// - reverse=true -> I want to provide `forDesired` output tokens and receive `quote.inAmount` input tokens.
+        /// - reverse=false -> I want to provide `quote.inAmount` `swapper.inType()` tokens and receive `quote.outAmount` `swapper.outType()` tokens.
+        /// - reverse=true -> I want to provide `quote.inAmount` `swapper.outType()` tokens and receive `quote.outAmount` `swapper.inType()` tokens.
+        /// `forDesired` names the requested output target in the quoted direction; implementations
+        /// may return less when liquidity is capped or slightly more when quote math rounds up.
         access(all) fun quoteIn(forDesired: UFix64, reverse: Bool): {Quote}
         /// The estimated amount delivered out for a provided input balance
-        /// Provides a quote for how many output tokens can be swapped for `forProvided` input tokens.
-        /// The reverse flag simply inverts inType/outType and inAmount/outAmount in the quote.
+        /// Provides a quote for the input and output amounts in the requested swap direction.
+        /// The reverse flag inverts the quoted token types, but quote.inAmount and quote.outAmount
+        /// always describe the amount of quote.inType provided for the amount of quote.outType
+        /// received.
         /// Interpretation:
-        /// - reverse=false -> I want to provide `forProvided` input tokens and receive `quote.outAmount` output tokens.
-        /// - reverse=true -> I want to provide `quote.outAmount` output tokens and receive `forProvided` input tokens.
+        /// - reverse=false -> I want to provide `quote.inAmount` `swapper.inType()` tokens and receive `quote.outAmount` `swapper.outType()` tokens.
+        /// - reverse=true -> I want to provide `quote.inAmount` `swapper.outType()` tokens and receive `quote.outAmount` `swapper.inType()` tokens.
+        /// `forProvided` names the requested input amount in the quoted direction; implementations
+        /// may return a smaller executable input amount when liquidity is capped.
         access(all) fun quoteOut(forProvided: UFix64, reverse: Bool): {Quote}
         /// Performs a swap taking a Vault of type inVault, outputting a resulting outVault. Implementations may choose
         /// to swap along a pre-set path or an optimal path of a set of paths or even set of contained Swappers adapted

--- a/cadence/tests/SwapConnectorsMultiSwapper_test.cdc
+++ b/cadence/tests/SwapConnectorsMultiSwapper_test.cdc
@@ -170,9 +170,54 @@ fun testQuoteOutPreferMaxOut() {
     let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
 
     Test.assertEqual(1, quote.swapperIndex)
+    Test.assertEqual(forProvided, quote.inAmount)
     Test.assertEqual(10.0 * 0.8, quote.outAmount)
     Test.assertEqual(inVaultType,  quote.inType)
     Test.assertEqual(outVaultType, quote.outType)
+}
+
+access(all)
+fun testQuoteInReversePreferMinInAmongFullCoverage() {
+    let forDesired = 10.0
+    let configs = [
+        makeConfig(priceRatio: 0.8, maxOut: 100.0),
+        makeConfig(priceRatio: 0.5, maxOut: 100.0)
+    ]
+
+    let result = executeScript(
+        "./scripts/multi-swapper/mock_quote_in.cdc",
+        [testTokenAccount.address, configs, inVaultType, outVaultType, forDesired, true]
+    )
+    Test.expect(result, Test.beSucceeded())
+    let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
+
+    Test.assertEqual(1, quote.swapperIndex)
+    Test.assertEqual(5.0, quote.inAmount)
+    Test.assertEqual(forDesired, quote.outAmount)
+    Test.assertEqual(outVaultType, quote.inType)
+    Test.assertEqual(inVaultType, quote.outType)
+}
+
+access(all)
+fun testQuoteOutReversePreferMaxOut() {
+    let forProvided = 10.0
+    let configs = [
+        makeConfig(priceRatio: 0.8, maxOut: 100.0),
+        makeConfig(priceRatio: 0.5, maxOut: 100.0)
+    ]
+
+    let result = executeScript(
+        "./scripts/multi-swapper/mock_quote_out.cdc",
+        [testTokenAccount.address, configs, inVaultType, outVaultType, forProvided, true]
+    )
+    Test.expect(result, Test.beSucceeded())
+    let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
+
+    Test.assertEqual(1, quote.swapperIndex)
+    Test.assertEqual(forProvided, quote.inAmount)
+    Test.assertEqual(20.0, quote.outAmount)
+    Test.assertEqual(outVaultType, quote.inType)
+    Test.assertEqual(inVaultType, quote.outType)
 }
 
 /// quoteOut — a cap constraint causes a higher-ratio route to deliver less output than a
@@ -199,6 +244,45 @@ fun testQuoteOutCapLimitsRoute() {
 
     Test.assertEqual(0, quote.swapperIndex)
     Test.assertEqual(5.0, quote.outAmount) // 10.0 * 0.5
+}
+
+access(all)
+fun testQuoteInPartialTieBreaksOnLowerInAmount() {
+    let forDesired = 10.0
+    let configs = [
+        makeConfig(priceRatio: 0.5, maxOut: 5.0),
+        makeConfig(priceRatio: 1.0, maxOut: 5.0)
+    ]
+
+    let result = executeScript(
+        "./scripts/multi-swapper/mock_quote_in.cdc",
+        [testTokenAccount.address, configs, inVaultType, outVaultType, forDesired, false]
+    )
+    Test.expect(result, Test.beSucceeded())
+    let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
+
+    Test.assertEqual(1, quote.swapperIndex)
+    Test.assertEqual(5.0, quote.inAmount)
+    Test.assertEqual(5.0, quote.outAmount)
+}
+
+access(all)
+fun testQuoteOutPreservesProvidedInputOnCappedRoute() {
+    let forProvided = 10.0
+    let configs = [
+        makeConfig(priceRatio: 1.0, maxOut: 4.0)
+    ]
+
+    let result = executeScript(
+        "./scripts/multi-swapper/mock_quote_out.cdc",
+        [testTokenAccount.address, configs, inVaultType, outVaultType, forProvided, false]
+    )
+    Test.expect(result, Test.beSucceeded())
+    let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
+
+    Test.assertEqual(0, quote.swapperIndex)
+    Test.assertEqual(forProvided, quote.inAmount)
+    Test.assertEqual(4.0, quote.outAmount)
 }
 
 access(all)
@@ -234,7 +318,9 @@ fun testSwapSourceWithdrawAvailableDoesNotExceedMaxAmount() {
 ///
 /// S1 and S2 tie on outAmount (110.0); S1 wins the tiebreaker (inAmount 88.0 < 100.0).
 /// S0 is eliminated by lower outAmount; S3 by lowest outAmount despite cheapest inAmount.
-/// Expected: index 1 (S1), outAmount=110.0, inAmount=88.0
+/// Expected: index 1 (S1), outAmount=110.0, inAmount=100.0
+/// The selected route still uses S1's lower inner inAmount as the tiebreaker,
+/// but the outward MultiSwapper quote preserves the caller-provided input amount.
 ///
 access(all)
 fun testQuoteOutMaxOutThenMinIn() {
@@ -255,7 +341,7 @@ fun testQuoteOutMaxOutThenMinIn() {
 
     Test.assertEqual(1, quote.swapperIndex)           // S1 wins
     Test.assertEqual(110.0, quote.outAmount)          // max outAmount
-    Test.assertEqual(88.0, quote.inAmount)            // 110.0 / 1.25
+    Test.assertEqual(forProvided, quote.inAmount)     // outward quote preserves provided input
 }
 
 /// quoteOut — a capacity-capped swapper that consumes less than forProvided (inAmount < forProvided)
@@ -269,7 +355,7 @@ fun testQuoteOutMaxOutThenMinIn() {
 ///   → inAmount=5.0 < forProvided=10.0, but outAmount=4.0 is the best available
 /// Swapper 1: priceRatio=0.2, maxOut=100.0
 ///   → rawOut = 10.0 * 0.2 = 2.0, uncapped → outAmount=2.0, inAmount=10.0
-/// Expected: index 0 (outAmount=4.0 > 2.0), even though inAmount=5.0 < forProvided=10.0
+/// Expected: index 0 (outAmount=4.0 > 2.0), while outward quote preserves inAmount=10.0
 ///
 access(all)
 fun testQuoteOutPartialConsumerWinsIfMoreOutput() {
@@ -288,5 +374,5 @@ fun testQuoteOutPartialConsumerWinsIfMoreOutput() {
 
     Test.assertEqual(0, quote.swapperIndex)
     Test.assertEqual(4.0, quote.outAmount)
-    Test.assertEqual(5.0, quote.inAmount) // only 5.0 of the 10.0 provided is consumed
+    Test.assertEqual(forProvided, quote.inAmount)
 }

--- a/cadence/tests/SwapConnectorsMultiSwapper_test.cdc
+++ b/cadence/tests/SwapConnectorsMultiSwapper_test.cdc
@@ -18,6 +18,17 @@ fun transferFlow(signer: Test.TestAccount, recipient: Address, amount: UFix64) {
     Test.expect(Test.executeTransaction(txn), Test.beSucceeded())
 }
 
+access(all)
+fun runTransaction(path: String, signer: Test.TestAccount, arguments: [AnyStruct]): Test.TransactionResult {
+    let txn = Test.Transaction(
+        code: Test.readFile(path),
+        authorizers: [signer.address],
+        signers: [signer],
+        arguments: arguments
+    )
+    return Test.executeTransaction(txn)
+}
+
 // inVault: TokenA, outVault: TokenB — shared across all multi-swapper tests
 access(all) let inVaultType  = Type<@TokenA.Vault>()
 access(all) let outVaultType = Type<@TokenB.Vault>()
@@ -188,4 +199,24 @@ fun testQuoteOutCapLimitsRoute() {
 
     Test.assertEqual(0, quote.swapperIndex)
     Test.assertEqual(5.0, quote.outAmount) // 10.0 * 0.5
+}
+
+access(all)
+fun testSwapWithQuoteOutFallbackSucceedsAgainstStrictInnerSwapper() {
+    let result = runTransaction(
+        path: "./transactions/multi-swapper/mock_strict_swap_quote_out.cdc",
+        signer: testTokenAccount,
+        arguments: [10.0, 1.0, 4.0]
+    )
+    Test.expect(result, Test.beSucceeded())
+}
+
+access(all)
+fun testSwapSourceWithdrawAvailableDoesNotExceedMaxAmount() {
+    let result = runTransaction(
+        path: "./transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc",
+        signer: testTokenAccount,
+        arguments: [10.0, 1.0]
+    )
+    Test.expect(result, Test.beSucceeded())
 }

--- a/cadence/tests/SwapConnectorsMultiSwapper_test.cdc
+++ b/cadence/tests/SwapConnectorsMultiSwapper_test.cdc
@@ -203,6 +203,8 @@ fun testQuoteOutCapLimitsRoute() {
 
 access(all)
 fun testSwapWithQuoteOutFallbackSucceedsAgainstStrictInnerSwapper() {
+    // args = [amountIn, priceRatio, maxOut]
+    // swap 10 TokenA at a 1:1 rate through a route that can output at most 4 TokenB
     let result = runTransaction(
         path: "./transactions/multi-swapper/mock_strict_swap_quote_out.cdc",
         signer: testTokenAccount,
@@ -213,6 +215,8 @@ fun testSwapWithQuoteOutFallbackSucceedsAgainstStrictInnerSwapper() {
 
 access(all)
 fun testSwapSourceWithdrawAvailableDoesNotExceedMaxAmount() {
+    // args = [maxAmount, quoteInOvershoot]
+    // ask for at most 10 TokenB while the mock quoteIn reports 1 extra TokenB
     let result = runTransaction(
         path: "./transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc",
         signer: testTokenAccount,

--- a/cadence/tests/contracts/MockSwapper.cdc
+++ b/cadence/tests/contracts/MockSwapper.cdc
@@ -200,4 +200,182 @@ access(all) contract MockSwapper {
         access(contract) view fun copyID(): DeFiActions.UniqueIdentifier? { return self.uniqueID }
         access(contract) fun setID(_ id: DeFiActions.UniqueIdentifier?) { self.uniqueID = id }
     }
+
+    /// TEST-ONLY strict capacity-limited swapper. Behaves like CapLimitedSwapper, but
+    /// also enforces that swaps do not exceed quote.inAmount.
+    access(all) struct StrictCapLimitedSwapper : DeFiActions.Swapper {
+        access(self) let inVault: Type
+        access(self) let outVault: Type
+        access(self) let inVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>
+        access(self) let outVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>
+        access(self) let priceRatio: UFix64
+        access(self) let maxOut: UFix64
+        access(contract) var uniqueID: DeFiActions.UniqueIdentifier?
+
+        init(
+            inVault: Type,
+            outVault: Type,
+            inVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>,
+            outVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>,
+            priceRatio: UFix64,
+            maxOut: UFix64,
+            uniqueID: DeFiActions.UniqueIdentifier?
+        ) {
+            pre {
+                inVault.isSubtype(of: Type<@{FungibleToken.Vault}>()): "inVault must be a FungibleToken Vault"
+                outVault.isSubtype(of: Type<@{FungibleToken.Vault}>()): "outVault must be a FungibleToken Vault"
+                inVaultSource.check(): "Invalid inVaultSource capability"
+                outVaultSource.check(): "Invalid outVaultSource capability"
+                priceRatio > 0.0: "Invalid price ratio"
+                maxOut > 0.0: "Invalid maxOut"
+            }
+            self.inVault = inVault
+            self.outVault = outVault
+            self.inVaultSource = inVaultSource
+            self.outVaultSource = outVaultSource
+            self.priceRatio = priceRatio
+            self.maxOut = maxOut
+            self.uniqueID = uniqueID
+        }
+
+        access(all) view fun inType(): Type { return self.inVault }
+        access(all) view fun outType(): Type { return self.outVault }
+
+        access(all) fun quoteIn(forDesired: UFix64, reverse: Bool): {DeFiActions.Quote} {
+            let actualOut = forDesired > self.maxOut ? self.maxOut : forDesired
+            let inAmt = reverse ? actualOut * self.priceRatio : actualOut / self.priceRatio
+            return BasicQuote(
+                inType: reverse ? self.outType() : self.inType(),
+                outType: reverse ? self.inType() : self.outType(),
+                inAmount: inAmt,
+                outAmount: actualOut
+            )
+        }
+
+        access(all) fun quoteOut(forProvided: UFix64, reverse: Bool): {DeFiActions.Quote} {
+            let rawOut = reverse ? forProvided / self.priceRatio : forProvided * self.priceRatio
+            let actualOut = rawOut > self.maxOut ? self.maxOut : rawOut
+            let actualIn = reverse ? actualOut * self.priceRatio : actualOut / self.priceRatio
+            return BasicQuote(
+                inType: reverse ? self.outType() : self.inType(),
+                outType: reverse ? self.inType() : self.outType(),
+                inAmount: actualIn,
+                outAmount: actualOut
+            )
+        }
+
+        access(all) fun swap(quote: {DeFiActions.Quote}?, inVault: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+            pre { inVault.getType() == self.inType(): "Wrong in type \(inVault.getType().identifier) - expected \(self.inType().identifier)" }
+            let appliedQuote = quote ?? self.quoteOut(forProvided: inVault.balance, reverse: false)
+            assert(inVault.balance <= appliedQuote.inAmount, message: "Swap input exceeds quote.inAmount")
+
+            let depositTo = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            depositTo.deposit(from: <-inVault)
+
+            let src = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            return <- src.withdraw(amount: appliedQuote.outAmount)
+        }
+
+        access(all) fun swapBack(quote: {DeFiActions.Quote}?, residual: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+            pre { residual.getType() == self.outType(): "Wrong out type \(residual.getType().identifier) - expected \(self.outType().identifier)" }
+            let appliedQuote = quote ?? self.quoteOut(forProvided: residual.balance, reverse: true)
+            assert(residual.balance <= appliedQuote.inAmount, message: "SwapBack input exceeds quote.inAmount")
+
+            let depositTo = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            depositTo.deposit(from: <-residual)
+
+            let src = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            return <- src.withdraw(amount: appliedQuote.outAmount)
+        }
+
+        access(all) fun getComponentInfo(): DeFiActions.ComponentInfo {
+            return DeFiActions.ComponentInfo(type: self.getType(), id: self.id(), innerComponents: [])
+        }
+        access(contract) view fun copyID(): DeFiActions.UniqueIdentifier? { return self.uniqueID }
+        access(contract) fun setID(_ id: DeFiActions.UniqueIdentifier?) { self.uniqueID = id }
+    }
+
+    /// TEST-ONLY swapper that returns a quoteIn outAmount above the requested amount.
+    access(all) struct QuoteInOvershootSwapper : DeFiActions.Swapper {
+        access(self) let inVault: Type
+        access(self) let outVault: Type
+        access(self) let inVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>
+        access(self) let outVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>
+        access(self) let priceRatio: UFix64
+        access(self) let quoteInOvershoot: UFix64
+        access(contract) var uniqueID: DeFiActions.UniqueIdentifier?
+
+        init(
+            inVault: Type,
+            outVault: Type,
+            inVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>,
+            outVaultSource: Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>,
+            priceRatio: UFix64,
+            quoteInOvershoot: UFix64,
+            uniqueID: DeFiActions.UniqueIdentifier?
+        ) {
+            pre {
+                inVault.isSubtype(of: Type<@{FungibleToken.Vault}>()): "inVault must be a FungibleToken Vault"
+                outVault.isSubtype(of: Type<@{FungibleToken.Vault}>()): "outVault must be a FungibleToken Vault"
+                inVaultSource.check(): "Invalid inVaultSource capability"
+                outVaultSource.check(): "Invalid outVaultSource capability"
+                priceRatio > 0.0: "Invalid price ratio"
+                quoteInOvershoot >= 0.0: "Invalid quoteInOvershoot"
+            }
+            self.inVault = inVault
+            self.outVault = outVault
+            self.inVaultSource = inVaultSource
+            self.outVaultSource = outVaultSource
+            self.priceRatio = priceRatio
+            self.quoteInOvershoot = quoteInOvershoot
+            self.uniqueID = uniqueID
+        }
+
+        access(all) view fun inType(): Type { return self.inVault }
+        access(all) view fun outType(): Type { return self.outVault }
+
+        access(all) fun quoteIn(forDesired: UFix64, reverse: Bool): {DeFiActions.Quote} {
+            let inAmt = reverse ? forDesired * self.priceRatio : forDesired / self.priceRatio
+            return BasicQuote(
+                inType: reverse ? self.outType() : self.inType(),
+                outType: reverse ? self.inType() : self.outType(),
+                inAmount: inAmt,
+                outAmount: forDesired + self.quoteInOvershoot
+            )
+        }
+
+        access(all) fun quoteOut(forProvided: UFix64, reverse: Bool): {DeFiActions.Quote} {
+            let outAmt = reverse ? forProvided / self.priceRatio : forProvided * self.priceRatio
+            return BasicQuote(
+                inType: reverse ? self.outType() : self.inType(),
+                outType: reverse ? self.inType() : self.outType(),
+                inAmount: forProvided,
+                outAmount: outAmt
+            )
+        }
+
+        access(all) fun swap(quote: {DeFiActions.Quote}?, inVault: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+            pre { inVault.getType() == self.inType(): "Wrong in type \(inVault.getType().identifier) - expected \(self.inType().identifier)" }
+            let outAmt = (quote?.outAmount) ?? (inVault.balance * self.priceRatio)
+            let depositTo = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            depositTo.deposit(from: <-inVault)
+            let src = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            return <- src.withdraw(amount: outAmt)
+        }
+
+        access(all) fun swapBack(quote: {DeFiActions.Quote}?, residual: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+            pre { residual.getType() == self.outType(): "Wrong out type \(residual.getType().identifier) - expected \(self.outType().identifier)" }
+            let inAmt = (quote?.inAmount) ?? (residual.balance / self.priceRatio)
+            let depositTo = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            depositTo.deposit(from: <-residual)
+            let src = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
+            return <- src.withdraw(amount: inAmt)
+        }
+
+        access(all) fun getComponentInfo(): DeFiActions.ComponentInfo {
+            return DeFiActions.ComponentInfo(type: self.getType(), id: self.id(), innerComponents: [])
+        }
+        access(contract) view fun copyID(): DeFiActions.UniqueIdentifier? { return self.uniqueID }
+        access(contract) fun setID(_ id: DeFiActions.UniqueIdentifier?) { self.uniqueID = id }
+    }
 }

--- a/cadence/tests/contracts/MockSwapper.cdc
+++ b/cadence/tests/contracts/MockSwapper.cdc
@@ -267,6 +267,7 @@ access(all) contract MockSwapper {
         access(all) fun swap(quote: {DeFiActions.Quote}?, inVault: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
             pre { inVault.getType() == self.inType(): "Wrong in type \(inVault.getType().identifier) - expected \(self.inType().identifier)" }
             let appliedQuote = quote ?? self.quoteOut(forProvided: inVault.balance, reverse: false)
+            // Special behavior for this mock: reject swaps whose input is larger than quote.inAmount.
             assert(inVault.balance <= appliedQuote.inAmount, message: "Swap input exceeds quote.inAmount")
 
             let depositTo = self.inVaultSource.borrow() ?? panic("Invalid borrowed vault source")
@@ -279,6 +280,7 @@ access(all) contract MockSwapper {
         access(all) fun swapBack(quote: {DeFiActions.Quote}?, residual: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
             pre { residual.getType() == self.outType(): "Wrong out type \(residual.getType().identifier) - expected \(self.outType().identifier)" }
             let appliedQuote = quote ?? self.quoteOut(forProvided: residual.balance, reverse: true)
+            // Same strict check in reverse, so swapBack also fails on quote/input mismatch.
             assert(residual.balance <= appliedQuote.inAmount, message: "SwapBack input exceeds quote.inAmount")
 
             let depositTo = self.outVaultSource.borrow() ?? panic("Invalid borrowed vault source")
@@ -340,6 +342,7 @@ access(all) contract MockSwapper {
                 inType: reverse ? self.outType() : self.inType(),
                 outType: reverse ? self.inType() : self.outType(),
                 inAmount: inAmt,
+                // Special behavior for this mock: quoteIn intentionally reports more out than requested.
                 outAmount: forDesired + self.quoteInOvershoot
             )
         }

--- a/cadence/tests/transactions/multi-swapper/mock_strict_swap_quote_out.cdc
+++ b/cadence/tests/transactions/multi-swapper/mock_strict_swap_quote_out.cdc
@@ -1,0 +1,52 @@
+import "FungibleToken"
+
+import "TokenA"
+import "TokenB"
+
+import "DeFiActions"
+import "SwapConnectors"
+import "MockSwapper"
+
+transaction(amountIn: UFix64, priceRatio: UFix64, maxOut: UFix64) {
+    let tokenBReceiver: &{FungibleToken.Receiver}
+    let multiSwapper: SwapConnectors.MultiSwapper
+    let expectedOut: UFix64
+    let inVault: @{FungibleToken.Vault}
+
+    prepare(signer: auth(Storage, Capabilities, BorrowValue) &Account) {
+        let tokenAVault = signer.storage.borrow<auth(FungibleToken.Withdraw) &TokenA.Vault>(from: TokenA.VaultStoragePath)
+            ?? panic("Missing TokenA vault")
+        self.tokenBReceiver = signer.capabilities.borrow<&{FungibleToken.Receiver}>(TokenB.ReceiverPublicPath)
+            ?? panic("Missing TokenB receiver")
+
+        self.inVault <- tokenAVault.withdraw(amount: amountIn)
+
+        let inCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenA.VaultStoragePath)
+        let outCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenB.VaultStoragePath)
+
+        self.multiSwapper = SwapConnectors.MultiSwapper(
+            inVault: Type<@TokenA.Vault>(),
+            outVault: Type<@TokenB.Vault>(),
+            swappers: [
+                MockSwapper.StrictCapLimitedSwapper(
+                    inVault: Type<@TokenA.Vault>(),
+                    outVault: Type<@TokenB.Vault>(),
+                    inVaultSource: inCap,
+                    outVaultSource: outCap,
+                    priceRatio: priceRatio,
+                    maxOut: maxOut,
+                    uniqueID: nil
+                )
+            ],
+            uniqueID: nil
+        )
+
+        self.expectedOut = amountIn * priceRatio > maxOut ? maxOut : amountIn * priceRatio
+    }
+
+    execute {
+        let outVault <- self.multiSwapper.swap(quote: nil, inVault: <-self.inVault)
+        assert(outVault.balance == self.expectedOut, message: "Unexpected output amount")
+        self.tokenBReceiver.deposit(from: <-outVault)
+    }
+}

--- a/cadence/tests/transactions/multi-swapper/mock_strict_swap_quote_out.cdc
+++ b/cadence/tests/transactions/multi-swapper/mock_strict_swap_quote_out.cdc
@@ -10,6 +10,10 @@ import "MockSwapper"
 /// Regression test:
 /// MultiSwapper.swap(quote: nil, ...) should still succeed when the selected
 /// inner route enforces `input <= quote.inAmount`.
+/// Args:
+/// - amountIn: TokenA sent into MultiSwapper
+/// - priceRatio: TokenB out per 1 TokenA in
+/// - maxOut: output cap enforced by the inner route
 transaction(amountIn: UFix64, priceRatio: UFix64, maxOut: UFix64) {
     let tokenBReceiver: &{FungibleToken.Receiver}
     let multiSwapper: SwapConnectors.MultiSwapper
@@ -46,7 +50,7 @@ transaction(amountIn: UFix64, priceRatio: UFix64, maxOut: UFix64) {
             uniqueID: nil
         )
 
-        // Expected output follows the inner swapper's cap.
+        // Expected output = min(amountIn * priceRatio, maxOut).
         self.expectedOut = amountIn * priceRatio > maxOut ? maxOut : amountIn * priceRatio
     }
 

--- a/cadence/tests/transactions/multi-swapper/mock_strict_swap_quote_out.cdc
+++ b/cadence/tests/transactions/multi-swapper/mock_strict_swap_quote_out.cdc
@@ -7,6 +7,9 @@ import "DeFiActions"
 import "SwapConnectors"
 import "MockSwapper"
 
+/// Regression test:
+/// MultiSwapper.swap(quote: nil, ...) should still succeed when the selected
+/// inner route enforces `input <= quote.inAmount`.
 transaction(amountIn: UFix64, priceRatio: UFix64, maxOut: UFix64) {
     let tokenBReceiver: &{FungibleToken.Receiver}
     let multiSwapper: SwapConnectors.MultiSwapper
@@ -19,11 +22,13 @@ transaction(amountIn: UFix64, priceRatio: UFix64, maxOut: UFix64) {
         self.tokenBReceiver = signer.capabilities.borrow<&{FungibleToken.Receiver}>(TokenB.ReceiverPublicPath)
             ?? panic("Missing TokenB receiver")
 
+        // Withdraw test input from the account's TokenA vault.
         self.inVault <- tokenAVault.withdraw(amount: amountIn)
 
         let inCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenA.VaultStoragePath)
         let outCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenB.VaultStoragePath)
 
+        // Single-route MultiSwapper using a strict capped inner swapper.
         self.multiSwapper = SwapConnectors.MultiSwapper(
             inVault: Type<@TokenA.Vault>(),
             outVault: Type<@TokenB.Vault>(),
@@ -41,10 +46,13 @@ transaction(amountIn: UFix64, priceRatio: UFix64, maxOut: UFix64) {
             uniqueID: nil
         )
 
+        // Expected output follows the inner swapper's cap.
         self.expectedOut = amountIn * priceRatio > maxOut ? maxOut : amountIn * priceRatio
     }
 
     execute {
+        // This call used to fail if MultiSwapper forwarded a quote whose
+        // inAmount no longer matched the provided vault balance.
         let outVault <- self.multiSwapper.swap(quote: nil, inVault: <-self.inVault)
         assert(outVault.balance == self.expectedOut, message: "Unexpected output amount")
         self.tokenBReceiver.deposit(from: <-outVault)

--- a/cadence/tests/transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc
+++ b/cadence/tests/transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc
@@ -7,6 +7,9 @@ import "FungibleTokenConnectors"
 import "SwapConnectors"
 import "MockSwapper"
 
+/// Regression test:
+/// SwapSource.withdrawAvailable(maxAmount) must not return more than maxAmount
+/// even if the chosen route's quoteIn reports a slightly larger outAmount.
 transaction(maxAmount: UFix64, quoteInOvershoot: UFix64) {
     let swapSource: SwapConnectors.SwapSource
     let tokenBReceiver: &{FungibleToken.Receiver}
@@ -18,11 +21,14 @@ transaction(maxAmount: UFix64, quoteInOvershoot: UFix64) {
         let inCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenA.VaultStoragePath)
         let outCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenB.VaultStoragePath)
 
+        // Source of TokenA liquidity to be wrapped by SwapSource.
         let source = FungibleTokenConnectors.VaultSource(
             min: nil,
             withdrawVault: inCap,
             uniqueID: nil
         )
+        // MultiSwapper with a single route whose quoteIn intentionally
+        // overshoots the requested outAmount.
         let swapper = SwapConnectors.MultiSwapper(
             inVault: Type<@TokenA.Vault>(),
             outVault: Type<@TokenB.Vault>(),
@@ -40,6 +46,8 @@ transaction(maxAmount: UFix64, quoteInOvershoot: UFix64) {
             uniqueID: nil
         )
 
+        // SwapSource is the integration point that previously leaked the
+        // overshoot back to callers.
         self.swapSource = SwapConnectors.SwapSource(
             swapper: swapper,
             source: source,
@@ -49,6 +57,7 @@ transaction(maxAmount: UFix64, quoteInOvershoot: UFix64) {
 
     execute {
         let outVault <- self.swapSource.withdrawAvailable(maxAmount: maxAmount)
+        // The returned vault must still be capped to the caller's request.
         assert(outVault.balance == maxAmount, message: "SwapSource withdrawAvailable exceeded maxAmount")
         self.tokenBReceiver.deposit(from: <-outVault)
     }

--- a/cadence/tests/transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc
+++ b/cadence/tests/transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc
@@ -10,6 +10,9 @@ import "MockSwapper"
 /// Regression test:
 /// SwapSource.withdrawAvailable(maxAmount) must not return more than maxAmount
 /// even if the chosen route's quoteIn reports a slightly larger outAmount.
+/// Args:
+/// - maxAmount: caller's requested maximum TokenB output
+/// - quoteInOvershoot: extra TokenB reported by the mock quoteIn
 transaction(maxAmount: UFix64, quoteInOvershoot: UFix64) {
     let swapSource: SwapConnectors.SwapSource
     let tokenBReceiver: &{FungibleToken.Receiver}

--- a/cadence/tests/transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc
+++ b/cadence/tests/transactions/multi-swapper/mock_swap_source_quote_in_overshoot.cdc
@@ -1,0 +1,55 @@
+import "FungibleToken"
+
+import "TokenA"
+import "TokenB"
+
+import "FungibleTokenConnectors"
+import "SwapConnectors"
+import "MockSwapper"
+
+transaction(maxAmount: UFix64, quoteInOvershoot: UFix64) {
+    let swapSource: SwapConnectors.SwapSource
+    let tokenBReceiver: &{FungibleToken.Receiver}
+
+    prepare(signer: auth(Storage, Capabilities, BorrowValue) &Account) {
+        self.tokenBReceiver = signer.capabilities.borrow<&{FungibleToken.Receiver}>(TokenB.ReceiverPublicPath)
+            ?? panic("Missing TokenB receiver")
+
+        let inCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenA.VaultStoragePath)
+        let outCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(TokenB.VaultStoragePath)
+
+        let source = FungibleTokenConnectors.VaultSource(
+            min: nil,
+            withdrawVault: inCap,
+            uniqueID: nil
+        )
+        let swapper = SwapConnectors.MultiSwapper(
+            inVault: Type<@TokenA.Vault>(),
+            outVault: Type<@TokenB.Vault>(),
+            swappers: [
+                MockSwapper.QuoteInOvershootSwapper(
+                    inVault: Type<@TokenA.Vault>(),
+                    outVault: Type<@TokenB.Vault>(),
+                    inVaultSource: inCap,
+                    outVaultSource: outCap,
+                    priceRatio: 1.0,
+                    quoteInOvershoot: quoteInOvershoot,
+                    uniqueID: nil
+                )
+            ],
+            uniqueID: nil
+        )
+
+        self.swapSource = SwapConnectors.SwapSource(
+            swapper: swapper,
+            source: source,
+            uniqueID: nil
+        )
+    }
+
+    execute {
+        let outVault <- self.swapSource.withdrawAvailable(maxAmount: maxAmount)
+        assert(outVault.balance == maxAmount, message: "SwapSource withdrawAvailable exceeded maxAmount")
+        self.tokenBReceiver.deposit(from: <-outVault)
+    }
+}


### PR DESCRIPTION
## Summary

This finishes the remaining `MultiSwapper` follow-up work after `#158`.

It keeps the improved route-selection behavior from `#158`, restores the outward quote semantics expected by existing callers, fixes the remaining partial-route tie case, and aligns the public `Swapper` documentation with the actual quote model used by the implementations.

## Remaining Issues From `#158`

1. `swap(nil, ...)` and `swapBack(nil, ...)` could become inconsistent with `quoteOut(...)`.
   In `#158`, `quoteOut(forProvided)` could return an inner route's smaller executable `inAmount`, while `MultiSwapper._swap(...)` still forwarded the full vault balance when it fell back to `quoteOut(from.balance)`.
   That broke strict or capacity-limited inner swappers that enforce `input <= quote.inAmount`.

   Example before this PR:
   - input vault balance = `10 TokenA`
   - inner route is capped at `4 TokenB`
   - raw inner `quoteOut(10)` = `{ inAmount: 4, outAmount: 4 }`
   - `_swap(...)` still forwards the full `10 TokenA` vault
   - strict inner swapper rejects the call because `10 > quote.inAmount (4)`

   Example after this PR:
   - outward `MultiSwapper.quoteOut(10)` = `{ inAmount: 10, outAmount: 4 }`
   - route selection still chooses the capped route
   - `swap(nil, ...)` and `swapBack(nil, ...)` remain consistent with the full vault balance being swapped
   - strict inner swappers no longer revert on the fallback path

2. `SwapSource.withdrawAvailable(maxAmount)` could return more than `maxAmount`.
   `quoteIn(forDesired)` started exposing the chosen route's raw `outAmount`, which can overshoot the requested amount due to rounding or quote refinement. `SwapSource` then forwarded that quote directly into `swap(...)`.

   Example before this PR:
   - caller requests `withdrawAvailable(maxAmount: 10)`
   - selected route returns `quoteIn(10) = { inAmount: 10, outAmount: 11 }`
   - `SwapSource` forwards that quote directly into `swap(...)`
   - caller receives `11`, even though `maxAmount` was `10`

   Example after this PR:
   - outward `MultiSwapper.quoteIn(10)` is clamped to `{ inAmount: 10, outAmount: 10 }`
   - `SwapSource.withdrawAvailable(maxAmount: 10)` cannot return more than `10`

3. `quoteIn(...)` still had a partial-route tie regression.
   When no route could fully satisfy `forDesired`, `#158` preferred the partial route with the highest `outAmount`, but if two partial routes had the same `outAmount` it kept the first one seen even if another route required less input.

   Example before this PR:
   - Route A: `{ inAmount: 10, outAmount: 5 }`
   - Route B: `{ inAmount: 5, outAmount: 5 }`
   - request: `quoteIn(forDesired: 10)`
   - both routes are partial and tie on `outAmount = 5`
   - `#158` keeps Route A if it appears first, even though Route B is strictly better

   Example after this PR:
   - same two routes
   - `quoteIn(forDesired: 10)` still falls back to the best partial route
   - tie on `outAmount` is broken by lower `inAmount`
   - Route B is chosen

4. The public `Swapper` interface comments were still not aligned with implementation behavior.
   The `reverse` flag flips the quoted token types, but the quote amounts still describe `quote.inType -> quote.outType` in the chosen direction.

   Example before this PR:
   - docs implied `reverse=true` should be interpreted as “provide `forDesired` output tokens and receive `quote.inAmount` input tokens”
   - implementations instead return quotes where `quote.inAmount` and `quote.outAmount` still describe the swap in the quoted direction, with only the token types flipped

   Example after this PR:
   - docs now state that `quote.inAmount` always refers to `quote.inType`
   - docs now state that `quote.outAmount` always refers to `quote.outType`
   - `reverse` is documented as changing the quoted token direction, not redefining what the quote fields mean

## Fix

- Reintroduce a shared `MultiSwapper._estimate(...)` helper that selects the winning route while preserving the improved `#158` route-selection rules.
- For `quoteIn(...)`, keep the selected route's `inAmount`, but clamp the outward `outAmount` to `forDesired`.
- For `quoteOut(...)`, keep the selected route's `outAmount`, but preserve `inAmount = forProvided` in the outward quote.
- Keep `quoteOut(...)` preferring the highest `outAmount`, with lower `inAmount` as a tiebreak when routes tie on output.
- Keep `quoteIn(...)` preferring full coverage over partial coverage, and prefer lower `inAmount` when partial routes tie on `outAmount`.
- Update the `Swapper` interface documentation so the quote semantics and `reverse` behavior match the current implementations.

## Tests

- `flow test ./cadence/tests/SwapConnectorsMultiSwapper_test.cdc`

Added or expanded regression coverage for:

- reverse-direction `quoteIn(...)` and `quoteOut(...)`
- `quoteIn(...)` partial-route tie breaking on lower `inAmount`
- `quoteOut(...)` preserving the caller-provided input amount on capped routes
- `swap(nil, ...)` succeeding against a strict capped inner swapper
- `SwapSource.withdrawAvailable(maxAmount)` never returning more than `maxAmount`
- existing `quoteOut(...)` route-selection behavior, including capped and partial-consumption routes
