### PR TITLE
Fix MultiSwapper partial quoteIn tie-break

### DIFF
--- a/cadence/contracts/connectors/SwapConnectors.cdc
+++ b/cadence/contracts/connectors/SwapConnectors.cdc
@@ -183,7 +183,8 @@ access(all) contract SwapConnectors {
                 } else if !hasFull {
                     // partial coverage group (only when no full route found)
                     // in this case, prefer maximum outAmount 
-                    if quote.outAmount > bestOutAmount {
+                    if quote.outAmount > bestOutAmount
+                        || (quote.outAmount == bestOutAmount && quote.inAmount < bestInAmount) {
                         bestIdx = i
                         bestInAmount = quote.inAmount
                         bestOutAmount = quote.outAmount

--- a/cadence/tests/SwapConnectorsMultiSwapper_test.cdc
+++ b/cadence/tests/SwapConnectorsMultiSwapper_test.cdc
@@ -190,6 +190,29 @@ fun testQuoteOutCapLimitsRoute() {
     Test.assertEqual(5.0, quote.outAmount) // 10.0 * 0.5
 }
 
+/// quoteIn — when two partial routes tie on outAmount, the one with the lower
+/// inAmount should win.
+///
+access(all)
+fun testQuoteInPartialTieBreaksOnLowerInAmount() {
+    let forDesired = 10.0
+    let configs = [
+        makeConfig(priceRatio: 0.5, maxOut: 5.0),
+        makeConfig(priceRatio: 1.0, maxOut: 5.0)
+    ]
+
+    let result = executeScript(
+        "./scripts/multi-swapper/mock_quote_in.cdc",
+        [testTokenAccount.address, configs, inVaultType, outVaultType, forDesired, false]
+    )
+    Test.expect(result, Test.beSucceeded())
+    let quote = result.returnValue! as! SwapConnectors.MultiSwapperQuote
+
+    Test.assertEqual(1, quote.swapperIndex)
+    Test.assertEqual(5.0, quote.inAmount)
+    Test.assertEqual(5.0, quote.outAmount)
+}
+
 /// quoteOut — four swappers: maximize outAmount first, then minimize inAmount as tiebreaker.
 ///
 /// S0 (suboptimal):  priceRatio=1.0,  maxOut=100.0 → outAmount=100.0, inAmount=100.0


### PR DESCRIPTION
## Summary

This PR fixes one remaining regression in `MultiSwapper.quoteIn(...)` from `#158`:

- when no route fully satisfies `forDesired`, and two partial routes tie on `outAmount`, prefer the route with the lower `inAmount`

The larger `quoteOut(...)` / `swap(nil, ...)` contract issue and the `SwapSource.withdrawAvailable(maxAmount)` overflow issue are deferred to `#168`.

## Root Cause

`#158` changed `quoteIn(...)` so partial routes were selected by maximum `outAmount`, but it dropped the previous lower-`inAmount` tie-break.

That means two partial routes with the same output now keep the first route seen, even if another route is strictly cheaper.

Example:
- Route A: `{ inAmount: 10, outAmount: 5 }`
- Route B: `{ inAmount: 5, outAmount: 5 }`
- request: `quoteIn(forDesired: 10)`
- both routes are partial and tie on `outAmount = 5`
- the better route is B, because it requires less input for the same output

## Changes

- in `MultiSwapper.quoteIn(...)`, keep the existing partial-route fallback from `#158`
- when two partial routes tie on `outAmount`, break the tie on lower `inAmount`
- add a focused regression test for that case

## Deferred Follow-up

- `#168` tracks the remaining `quoteOut(...)` / `swap(nil, ...)` mismatch
- `#168` also tracks `SwapSource.withdrawAvailable(maxAmount)` returning more than `maxAmount`

## Validation

- `flow test ./cadence/tests/SwapConnectorsMultiSwapper_test.cdc`
