### PR TITLE
fix(S1): Inconsistent Error Handling Patterns Across Connectors

### DIFF
--- a/cadence/contracts/connectors/evm/ERC4626SinkConnectors.cdc
+++ b/cadence/contracts/connectors/evm/ERC4626SinkConnectors.cdc
@@ -132,15 +132,16 @@ access(all) contract ERC4626SinkConnectors {
             // approve the ERC4626 vault to spend the assets on deposit
             let uintAmount = FlowEVMBridgeUtils.convertCadenceAmountToERC20Amount(amount, erc20Address: self.assetEVMAddress)
             let approveRes = self._call(
-                    to: self.assetEVMAddress,
-                    signature: "approve(address,uint256)",
-                    args: [self.vault, uintAmount],
-                    gasLimit: 500_000
-                )!
-            if approveRes.status != EVM.Status.successful {
-                // Cadence panic reverts all EVM state changes in this transaction, so no need to bridge token back.
-                panic(self._approveErrorMessage(ufixAmount: amount, uintAmount: uintAmount, approveRes: approveRes))
-            }
+                to: self.assetEVMAddress,
+                signature: "approve(address,uint256)",
+                args: [self.vault, uintAmount],
+                gasLimit: 500_000
+            )!
+            // Cadence panic reverts all EVM state changes in this transaction, so no need to bridge token back.
+            assert(
+                approveRes.status == EVM.Status.successful,
+                message: self._approveErrorMessage(ufixAmount: amount, uintAmount: uintAmount, approveRes: approveRes)
+            )
 
             // deposit the assets to the ERC4626 vault
             let depositRes = self._call(
@@ -149,11 +150,12 @@ access(all) contract ERC4626SinkConnectors {
                 args: [uintAmount, self.coa.borrow()!.address()],
                 gasLimit: 1_000_000
             )!
-            if depositRes.status != EVM.Status.successful {
-                // No need to revoke the approval: a Cadence panic atomically reverts all EVM
-                // state changes made in this transaction, including the approve() call above.
-                panic(self._depositErrorMessage(ufixAmount: amount, uintAmount: uintAmount, depositRes: depositRes))
-            }
+            // No need to revoke the approval: a Cadence panic atomically reverts all EVM
+            // state changes made in this transaction, including the approve() call above.
+            assert(
+                depositRes.status == EVM.Status.successful,
+                message: self._depositErrorMessage(ufixAmount: amount, uintAmount: uintAmount, depositRes: depositRes)
+            )
         }
         /// Returns a ComponentInfo struct containing information about this component and a list of ComponentInfo for
         /// each inner component in the stack.

--- a/cadence/contracts/connectors/evm/EVMTokenConnectors.cdc
+++ b/cadence/contracts/connectors/evm/EVMTokenConnectors.cdc
@@ -125,9 +125,11 @@ access(all) contract EVMTokenConnectors {
 
             // collect VM bridge fees
             let feeAmount = FlowEVMBridgeConfig.baseFee
-            if self.feeSource.minimumAvailable() < feeAmount {
-                return // early return here instead of reverting in bridge scope on insufficient fees
-            }
+            let availableFees = self.feeSource.minimumAvailable()
+            assert(
+                availableFees >= feeAmount,
+                message: "Fee source \(availableFees.toString()) cannot cover bridging base fee \(feeAmount.toString())"
+            )
             let fees <- self.feeSource.withdrawAvailable(maxAmount: feeAmount)
 
             // deposit tokens and handle remaining fees

--- a/cadence/contracts/connectors/evm/EVMTokenConnectors.cdc
+++ b/cadence/contracts/connectors/evm/EVMTokenConnectors.cdc
@@ -126,6 +126,9 @@ access(all) contract EVMTokenConnectors {
             // collect VM bridge fees
             let feeAmount = FlowEVMBridgeConfig.baseFee
             let availableFees = self.feeSource.minimumAvailable()
+            // We could return early here, but that would silently hide the fact
+            // that `self.feeSource`, which is responsible for paying bridging fees,
+            // has in fact run out of funds.
             assert(
                 availableFees >= feeAmount,
                 message: "Fee source \(availableFees.toString()) cannot cover bridging base fee \(feeAmount.toString())"

--- a/cadence/contracts/connectors/evm/EVMTokenConnectors.cdc
+++ b/cadence/contracts/connectors/evm/EVMTokenConnectors.cdc
@@ -125,14 +125,9 @@ access(all) contract EVMTokenConnectors {
 
             // collect VM bridge fees
             let feeAmount = FlowEVMBridgeConfig.baseFee
-            let availableFees = self.feeSource.minimumAvailable()
-            // We could return early here, but that would silently hide the fact
-            // that `self.feeSource`, which is responsible for paying bridging fees,
-            // has in fact run out of funds.
-            assert(
-                availableFees >= feeAmount,
-                message: "Fee source \(availableFees.toString()) cannot cover bridging base fee \(feeAmount.toString())"
-            )
+            if self.feeSource.minimumAvailable() < feeAmount {
+                return // early return here instead of reverting in bridge scope on insufficient fees
+            }
             let fees <- self.feeSource.withdrawAvailable(maxAmount: feeAmount)
 
             // deposit tokens and handle remaining fees

--- a/cadence/contracts/interfaces/DeFiActions.cdc
+++ b/cadence/contracts/interfaces/DeFiActions.cdc
@@ -258,8 +258,8 @@ access(all) contract DeFiActions {
     /// A Sink Connector (or just “Sink”) is analogous to the Fungible Token Receiver interface that accepts deposits of
     /// funds. It differs from the standard Receiver interface in that it is a struct interface (instead of resource
     /// interface) and allows for the graceful handling of Sinks that have a limited capacity on the amount they can
-    /// accept for deposit. Implementations should therefore avoid the possibility of reversion with graceful fallback
-    /// on unexpected conditions, executing no-ops instead of reverting.
+    /// accept for deposit. Implementations should therefore favor graceful fallback on unmet conditions, such as zero
+    /// capacity, executing no-ops instead of reverting. Any errors that hinder liveness, can be surfaced for visibility.
     ///
     access(all) struct interface Sink : IdentifiableStruct {
         /// Returns the Vault type accepted by this Sink

--- a/cadence/contracts/interfaces/DeFiActions.cdc
+++ b/cadence/contracts/interfaces/DeFiActions.cdc
@@ -258,9 +258,12 @@ access(all) contract DeFiActions {
     /// A Sink Connector (or just “Sink”) is analogous to the Fungible Token Receiver interface that accepts deposits of
     /// funds. It differs from the standard Receiver interface in that it is a struct interface (instead of resource
     /// interface) and allows for the graceful handling of Sinks that have a limited capacity on the amount they can
-    /// accept for deposit. Implementations should therefore favor graceful fallback on unmet conditions, such as zero
-    /// capacity, executing no-ops instead of reverting. Any errors that hinder liveness, can be surfaced for visibility.
-    ///
+    /// accept for deposit. Implementations should therefore favor graceful fallback on unexpected conditions, executing
+    /// no-ops instead of reverting.
+    /// - A Sink should prioritize liveness where possible, and not panic, for example if it has no funds or cannot
+    ///   access funds.
+    /// - A sink should only panic if not panicking would cause the Sink to have an inconsistent internal state
+    ///   (unsafe or undefined for the Sink to continue in this state).
     access(all) struct interface Sink : IdentifiableStruct {
         /// Returns the Vault type accepted by this Sink
         access(all) view fun getSinkType(): Type


### PR DESCRIPTION
Closes: https://github.com/onflow/FlowActions/issues/111

***

Regarding the inconsistent error handling between the two implementations of `DeFiActions.Sink` (that is `ERC4626SinkConnectors` & `EVMTokenConnectors`). The doc section on `DeFiActions.Sink` states:

```cadence
/// Sink
///
/// A Sink Connector (or just “Sink”) is analogous to the Fungible Token Receiver interface that accepts deposits of
/// funds. It differs from the standard Receiver interface in that it is a struct interface (instead of resource
/// interface) and allows for the graceful handling of Sinks that have a limited capacity on the amount they can
/// accept for deposit. Implementations should therefore avoid the possibility of reversion with graceful fallback
/// on unexpected conditions, executing no-ops instead of reverting.
///
```

The documentation already describes the desired error handling: `executing no-ops instead of reverting`. The only reason that `ERC4626SinkConnectors` panics, is in order to undo the effect of a `from.withdraw(amount: amount)` `FungibleToken` Vault withdrawal and an `approve(address,uint256)` ERC-20 call. For the method's implementation, the `panic` is a good safety measure to ensure the logic is atomic. If the funds are withdrawn from the given vault, then they have to be deposited to the destination address, so both steps have to be successful, or both have to fail. It is good practice to also avoid the silent early return on `EVMTokenConnectors.Sink.depositCapacity()`, as it doesn't surface the underlying issue which causes the method to stop functioning properly, due to low fees.

***

Regarding the `Return nil/0.0` pattern used on the two implementations of `DeFiActions.Swapper` (that is `UniswapV3SwapConnectors` & `ERC4626SwapConnectors`). Both quote functions:
- `quoteIn(forDesired: UFix64, reverse: Bool): {Quote}`
- `quoteOut(forProvided: UFix64, reverse: Bool): {Quote}`

have to return a struct that adheres to the `Quote` interface. The documentation already describes a convention there:
```cadence
/// Quote
///
/// An interface for an estimate to be returned by a Swapper when asking for a swap estimate. This may be helpful
/// for passing additional parameters to a Swapper relevant to the use case. Implementations may choose to add
/// fields relevant to their Swapper implementation and downcast in swap() and/or swapBack() scope.
/// By convention, a Quote with inAmount==outAmount==0 indicates no estimated swap price is available.
///
```

The convention for using `0.0` as values in `inAmount` & `outAmount` is to denote that no estimated swap price is available. Given that Cadence doesn't have a `try/catch` construct, the usage of `panic` aborts the transaction, without giving the caller a chance to handle/recover. So it makes sense to return an optional value in some cases, such as `UFix64?`, which means that it can also be `nil`. This allows the caller to handle certain cases more gracefully.