### PR TITLE
Optimize iteration over dictionary keys

### DIFF
--- a/.github/workflows/cadence_tests.yml
+++ b/.github/workflows/cadence_tests.yml
@@ -23,7 +23,7 @@ jobs:
           path: ./imports
           key: flow-deps-${{ hashFiles('flow.json') }}
       - name: Install Flow CLI
-        run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)" -- v2.15.3
+        run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)" -- v2.16.0
       - name: Flow CLI Version
         run: flow version
       - name: Update PATH and show Flow version

--- a/cadence/contracts/interfaces/DeFiActions.cdc
+++ b/cadence/contracts/interfaces/DeFiActions.cdc
@@ -1115,7 +1115,7 @@ access(all) contract DeFiActions {
             }
 
             // check for other scheduled transactions within the desired interval
-            for id in self._scheduledTransactions.keys {
+            for id in self._scheduledTransactions {
                 if id == whileExecuting {
                     continue
                 }
@@ -1244,7 +1244,7 @@ access(all) contract DeFiActions {
             let limit = 50
             var iter = 0
             // iterate over the scheduled transactions and remove those that are not scheduled
-            for id in self._scheduledTransactions.keys {
+            for id in self._scheduledTransactions {
                 iter = iter + 1
                 if iter > limit {
                     break


### PR DESCRIPTION
Since [Cadence v1.10.0](https://github.com/onflow/cadence/releases/tag/v1.10.0) direct iteration over dictionaries is supported, which avoids temporarily constructing an array of all keys.
